### PR TITLE
Use vim-pathogen plugin

### DIFF
--- a/modules/home/vim.nix
+++ b/modules/home/vim.nix
@@ -4,7 +4,7 @@
     enable = true;
     plugins = with pkgs.vimPlugins; [
       vim-airline
-      pathogen
+      vim-pathogen
     ];
     extraConfig = builtins.readFile ./vimrc;
   };


### PR DESCRIPTION
## Summary

  This PR updates the Vim plugin reference in Home Manager from the deprecated vimPlugins.pathogen attribute to vimPlugins.vim-pathogen.

  ## Context

  nix flake check was emitting an evaluation warning that vimPlugins.pathogen was renamed on February 4, 2026. The old attribute still evaluated, but produced warning noise during checks.

  ## Changes

  - modules/home/vim.nix
      - Replaced pathogen with vim-pathogen in programs.vim.plugins.

  ## Validation

  Ran:

  - nix flake check

