### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770896158,
-        "narHash": "sha256-ktNIry6OR+Aq0tBql5nHS39rt7sgEuBhpD8t9uJDDiA=",
+        "lastModified": 1770927256,
+        "narHash": "sha256-R/RoNtWU8LHFUK5nGRIewLipM8Dgme9YNHLxzGIXDfM=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "5d41d836ea68e1daf850b009f834215b708b9735",
+        "rev": "00619f4aa35f3c027a866ec7c51105ccbb49e3ef",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770818644,
-        "narHash": "sha256-DYS4jIRpRoKOzJjnR/QqEd/MlT4OZZpt8CrBLv+cjsE=",
+        "lastModified": 1770975156,
+        "narHash": "sha256-bPKv7BcIOGp4R1Q3hKhiD2CT3+7D6ibNIaJfEJdeOzo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0acbd1180697de56724821184ad2c3e6e7202cd7",
+        "rev": "de4cfffc98f43ab8ba90739b56991f068f9e9018",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770562336,
-        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "lastModified": 1770841267,
+        "narHash": "sha256-9xejG0KoqsoKEGp2kVbXRlEYtFFcDTHjidiuX8hGO44=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
+        "rev": "ec7c70d12ce2fc37cb92aff673dcdca89d187bae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`5d41d83`](https://github.com/sadjow/codex-cli-nix/commit/5d41d836ea68e1daf850b009f834215b708b9735) -> [`00619f4`](https://github.com/sadjow/codex-cli-nix/commit/00619f4aa35f3c027a866ec7c51105ccbb49e3ef) ([compare](https://github.com/sadjow/codex-cli-nix/compare/5d41d836ea68e1daf850b009f834215b708b9735...00619f4aa35f3c027a866ec7c51105ccbb49e3ef))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`0acbd11`](https://github.com/nix-community/home-manager/commit/0acbd1180697de56724821184ad2c3e6e7202cd7) -> [`de4cfff`](https://github.com/nix-community/home-manager/commit/de4cfffc98f43ab8ba90739b56991f068f9e9018) ([compare](https://github.com/nix-community/home-manager/compare/0acbd1180697de56724821184ad2c3e6e7202cd7...de4cfffc98f43ab8ba90739b56991f068f9e9018))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`d6c7193`](https://github.com/nixos/nixpkgs/commit/d6c71932130818840fc8fe9509cf50be8c64634f) -> [`ec7c70d`](https://github.com/nixos/nixpkgs/commit/ec7c70d12ce2fc37cb92aff673dcdca89d187bae) ([compare](https://github.com/nixos/nixpkgs/compare/d6c71932130818840fc8fe9509cf50be8c64634f...ec7c70d12ce2fc37cb92aff673dcdca89d187bae))
