### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770975156,
-        "narHash": "sha256-bPKv7BcIOGp4R1Q3hKhiD2CT3+7D6ibNIaJfEJdeOzo=",
+        "lastModified": 1771037579,
+        "narHash": "sha256-NX5XuhGcsmk0oEII2PEtMRgvh2KaAv3/WWQsOpxAgR4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "de4cfffc98f43ab8ba90739b56991f068f9e9018",
+        "rev": "05e6dc0f6ed936f918cb6f0f21f1dad1e4c53150",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`de4cfff`](https://github.com/nix-community/home-manager/commit/de4cfffc98f43ab8ba90739b56991f068f9e9018) -> [`05e6dc0`](https://github.com/nix-community/home-manager/commit/05e6dc0f6ed936f918cb6f0f21f1dad1e4c53150) ([compare](https://github.com/nix-community/home-manager/compare/de4cfffc98f43ab8ba90739b56991f068f9e9018...05e6dc0f6ed936f918cb6f0f21f1dad1e4c53150))
