### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770975156,
-        "narHash": "sha256-bPKv7BcIOGp4R1Q3hKhiD2CT3+7D6ibNIaJfEJdeOzo=",
+        "lastModified": 1771188132,
+        "narHash": "sha256-qLXxN/tPrZtnekaLBQuVtxQfvqqs5cT5WbyH4zZaTGI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "de4cfffc98f43ab8ba90739b56991f068f9e9018",
+        "rev": "ae8003d8b61d0d373e7ca3da1a48f9c870d15df9",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770315571,
-        "narHash": "sha256-hy0gcAgAcxrnSWKGuNO+Ob0x6jQ2xkR6hoaR0qJBHYs=",
+        "lastModified": 1771130777,
+        "narHash": "sha256-UIKOwG0D9XVIJfNWg6+gENAvQP+7LO46eO0Jpe+ItJ0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "2684bb8080a6f2ca5f9d494de5ef875bc1c4ecdb",
+        "rev": "efec7aaad8d43f8e5194df46a007456093c40f88",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1770882871,
-        "narHash": "sha256-nw5g+xl3veea+maxJ2/81tMEA/rPq9aF1H5XF35X+OE=",
+        "lastModified": 1771171797,
+        "narHash": "sha256-ngIarpog/Hv5r9M1YyvsaaSUBCqtWqHl6pibq6n2ppo=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "af04cb78aa85b2a4d1c15fc7270347e0d0eda97b",
+        "rev": "531af1dbaee7cfdd7aed1e595ce418b7e2e99a80",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770841267,
-        "narHash": "sha256-9xejG0KoqsoKEGp2kVbXRlEYtFFcDTHjidiuX8hGO44=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ec7c70d12ce2fc37cb92aff673dcdca89d187bae",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`de4cfff`](https://github.com/nix-community/home-manager/commit/de4cfffc98f43ab8ba90739b56991f068f9e9018) -> [`ae8003d`](https://github.com/nix-community/home-manager/commit/ae8003d8b61d0d373e7ca3da1a48f9c870d15df9) ([compare](https://github.com/nix-community/home-manager/compare/de4cfffc98f43ab8ba90739b56991f068f9e9018...ae8003d8b61d0d373e7ca3da1a48f9c870d15df9))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`2684bb8`](https://github.com/Mic92/nix-index-database/commit/2684bb8080a6f2ca5f9d494de5ef875bc1c4ecdb) -> [`efec7aa`](https://github.com/Mic92/nix-index-database/commit/efec7aaad8d43f8e5194df46a007456093c40f88) ([compare](https://github.com/Mic92/nix-index-database/compare/2684bb8080a6f2ca5f9d494de5ef875bc1c4ecdb...efec7aaad8d43f8e5194df46a007456093c40f88))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`af04cb7`](https://github.com/nixos/nixos-hardware/commit/af04cb78aa85b2a4d1c15fc7270347e0d0eda97b) -> [`531af1d`](https://github.com/nixos/nixos-hardware/commit/531af1dbaee7cfdd7aed1e595ce418b7e2e99a80) ([compare](https://github.com/nixos/nixos-hardware/compare/af04cb78aa85b2a4d1c15fc7270347e0d0eda97b...531af1dbaee7cfdd7aed1e595ce418b7e2e99a80))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`ec7c70d`](https://github.com/nixos/nixpkgs/commit/ec7c70d12ce2fc37cb92aff673dcdca89d187bae) -> [`a82ccc3`](https://github.com/nixos/nixpkgs/commit/a82ccc39b39b621151d6732718e3e250109076fa) ([compare](https://github.com/nixos/nixpkgs/compare/ec7c70d12ce2fc37cb92aff673dcdca89d187bae...a82ccc39b39b621151d6732718e3e250109076fa))
