### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770927256,
-        "narHash": "sha256-R/RoNtWU8LHFUK5nGRIewLipM8Dgme9YNHLxzGIXDfM=",
+        "lastModified": 1771369907,
+        "narHash": "sha256-qhoU0EvdLQ6jLjJXBWrqfwV8E7xAi8ZOLFg20Xs0sio=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "00619f4aa35f3c027a866ec7c51105ccbb49e3ef",
+        "rev": "aaa67a5325a0b05058b97f219eeb5ccf08d4d2c9",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771188132,
-        "narHash": "sha256-qLXxN/tPrZtnekaLBQuVtxQfvqqs5cT5WbyH4zZaTGI=",
+        "lastModified": 1771269455,
+        "narHash": "sha256-BZ31eN5F99YH6vkc4AhzKGE+tJgJ52kl8f01K7wCs8w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ae8003d8b61d0d373e7ca3da1a48f9c870d15df9",
+        "rev": "5f1d42a97b19803041434f66681d5c44c9ae62e3",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1771171797,
-        "narHash": "sha256-ngIarpog/Hv5r9M1YyvsaaSUBCqtWqHl6pibq6n2ppo=",
+        "lastModified": 1771257191,
+        "narHash": "sha256-H1l+zHq+ZinWH7F1IidpJ2farmbfHXjaxAm1RKWE1KI=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "531af1dbaee7cfdd7aed1e595ce418b7e2e99a80",
+        "rev": "66e1a090ded57a0f88e2b381a7d4daf4a5722c3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`00619f4`](https://github.com/sadjow/codex-cli-nix/commit/00619f4aa35f3c027a866ec7c51105ccbb49e3ef) -> [`aaa67a5`](https://github.com/sadjow/codex-cli-nix/commit/aaa67a5325a0b05058b97f219eeb5ccf08d4d2c9) ([compare](https://github.com/sadjow/codex-cli-nix/compare/00619f4aa35f3c027a866ec7c51105ccbb49e3ef...aaa67a5325a0b05058b97f219eeb5ccf08d4d2c9))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`ae8003d`](https://github.com/nix-community/home-manager/commit/ae8003d8b61d0d373e7ca3da1a48f9c870d15df9) -> [`5f1d42a`](https://github.com/nix-community/home-manager/commit/5f1d42a97b19803041434f66681d5c44c9ae62e3) ([compare](https://github.com/nix-community/home-manager/compare/ae8003d8b61d0d373e7ca3da1a48f9c870d15df9...5f1d42a97b19803041434f66681d5c44c9ae62e3))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`531af1d`](https://github.com/nixos/nixos-hardware/commit/531af1dbaee7cfdd7aed1e595ce418b7e2e99a80) -> [`66e1a09`](https://github.com/nixos/nixos-hardware/commit/66e1a090ded57a0f88e2b381a7d4daf4a5722c3f) ([compare](https://github.com/nixos/nixos-hardware/compare/531af1dbaee7cfdd7aed1e595ce418b7e2e99a80...66e1a090ded57a0f88e2b381a7d4daf4a5722c3f))
