### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771369907,
-        "narHash": "sha256-qhoU0EvdLQ6jLjJXBWrqfwV8E7xAi8ZOLFg20Xs0sio=",
+        "lastModified": 1771399619,
+        "narHash": "sha256-N6EixHow33gRNkAhHr7ySRBXPxtS1Eg2PZGcL1Me/cI=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "aaa67a5325a0b05058b97f219eeb5ccf08d4d2c9",
+        "rev": "002b92b5bc5ff930e5071b275d20453515a495a9",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771269455,
-        "narHash": "sha256-BZ31eN5F99YH6vkc4AhzKGE+tJgJ52kl8f01K7wCs8w=",
+        "lastModified": 1771471179,
+        "narHash": "sha256-XuP8HPzvt4+m9aKVeL9GdGNlTeyeDn3zEeUuorvrw88=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5f1d42a97b19803041434f66681d5c44c9ae62e3",
+        "rev": "2dedeb55b2c140d9a123ae931588e8903fe202ef",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1771257191,
-        "narHash": "sha256-H1l+zHq+ZinWH7F1IidpJ2farmbfHXjaxAm1RKWE1KI=",
+        "lastModified": 1771423359,
+        "narHash": "sha256-yRKJ7gpVmXbX2ZcA8nFi6CMPkJXZGjie2unsiMzj3Ig=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "66e1a090ded57a0f88e2b381a7d4daf4a5722c3f",
+        "rev": "740a22363033e9f1bb6270fbfb5a9574067af15b",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771008912,
-        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`aaa67a5`](https://github.com/sadjow/codex-cli-nix/commit/aaa67a5325a0b05058b97f219eeb5ccf08d4d2c9) -> [`002b92b`](https://github.com/sadjow/codex-cli-nix/commit/002b92b5bc5ff930e5071b275d20453515a495a9) ([compare](https://github.com/sadjow/codex-cli-nix/compare/aaa67a5325a0b05058b97f219eeb5ccf08d4d2c9...002b92b5bc5ff930e5071b275d20453515a495a9))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`5f1d42a`](https://github.com/nix-community/home-manager/commit/5f1d42a97b19803041434f66681d5c44c9ae62e3) -> [`2dedeb5`](https://github.com/nix-community/home-manager/commit/2dedeb55b2c140d9a123ae931588e8903fe202ef) ([compare](https://github.com/nix-community/home-manager/compare/5f1d42a97b19803041434f66681d5c44c9ae62e3...2dedeb55b2c140d9a123ae931588e8903fe202ef))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`66e1a09`](https://github.com/nixos/nixos-hardware/commit/66e1a090ded57a0f88e2b381a7d4daf4a5722c3f) -> [`740a223`](https://github.com/nixos/nixos-hardware/commit/740a22363033e9f1bb6270fbfb5a9574067af15b) ([compare](https://github.com/nixos/nixos-hardware/compare/66e1a090ded57a0f88e2b381a7d4daf4a5722c3f...740a22363033e9f1bb6270fbfb5a9574067af15b))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`a82ccc3`](https://github.com/nixos/nixpkgs/commit/a82ccc39b39b621151d6732718e3e250109076fa) -> [`0182a36`](https://github.com/nixos/nixpkgs/commit/0182a361324364ae3f436a63005877674cf45efb) ([compare](https://github.com/nixos/nixpkgs/compare/a82ccc39b39b621151d6732718e3e250109076fa...0182a361324364ae3f436a63005877674cf45efb))
