### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771647911,
-        "narHash": "sha256-18liNHHwOmcaKCpOptE3wLW97fm5v7RTLiZBecX7km0=",
+        "lastModified": 1771683283,
+        "narHash": "sha256-WxAEkAbo8dP7qiyPM6VN4ZGAxfuBVlNBNPkrqkrXVEc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "436b27742c996b75e2baf8e835e3b3eae0c9fbd4",
+        "rev": "c6ed3eab64d23520bcbb858aa53fe2b533725d4a",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771130777,
-        "narHash": "sha256-UIKOwG0D9XVIJfNWg6+gENAvQP+7LO46eO0Jpe+ItJ0=",
+        "lastModified": 1771734689,
+        "narHash": "sha256-/phvMgr1yutyAMjKnZlxkVplzxHiz60i4rc+gKzpwhg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "efec7aaad8d43f8e5194df46a007456093c40f88",
+        "rev": "8f590b832326ab9699444f3a48240595954a4b10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`436b277`](https://github.com/nix-community/home-manager/commit/436b27742c996b75e2baf8e835e3b3eae0c9fbd4) -> [`c6ed3ea`](https://github.com/nix-community/home-manager/commit/c6ed3eab64d23520bcbb858aa53fe2b533725d4a) ([compare](https://github.com/nix-community/home-manager/compare/436b27742c996b75e2baf8e835e3b3eae0c9fbd4...c6ed3eab64d23520bcbb858aa53fe2b533725d4a))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`efec7aa`](https://github.com/Mic92/nix-index-database/commit/efec7aaad8d43f8e5194df46a007456093c40f88) -> [`8f590b8`](https://github.com/Mic92/nix-index-database/commit/8f590b832326ab9699444f3a48240595954a4b10) ([compare](https://github.com/Mic92/nix-index-database/compare/efec7aaad8d43f8e5194df46a007456093c40f88...8f590b832326ab9699444f3a48240595954a4b10))
