### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771399619,
-        "narHash": "sha256-N6EixHow33gRNkAhHr7ySRBXPxtS1Eg2PZGcL1Me/cI=",
+        "lastModified": 1772152654,
+        "narHash": "sha256-PACE/u1ufOZYOwYfojgOwJlOsoGshVCQb0C6IbiTLN8=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "002b92b5bc5ff930e5071b275d20453515a495a9",
+        "rev": "1639f2d679d181e29a87a49b83d01a5d5cd2a0c6",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770726378,
-        "narHash": "sha256-kck+vIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8=",
+        "lastModified": 1772024342,
+        "narHash": "sha256-+eXlIc4/7dE6EcPs9a2DaSY3fTA9AE526hGqkNID3Wg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
+        "rev": "6e34e97ed9788b17796ee43ccdbaf871a5c2b476",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771683283,
-        "narHash": "sha256-WxAEkAbo8dP7qiyPM6VN4ZGAxfuBVlNBNPkrqkrXVEc=",
+        "lastModified": 1772164835,
+        "narHash": "sha256-zRcwrZDeBfYipqv/7K7TqsfPb87LFU6b7JhoNUGSnvQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c6ed3eab64d23520bcbb858aa53fe2b533725d4a",
+        "rev": "2a39b0828bbffce0d73769a61e46e780488d098b",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1771423359,
-        "narHash": "sha256-yRKJ7gpVmXbX2ZcA8nFi6CMPkJXZGjie2unsiMzj3Ig=",
+        "lastModified": 1771969195,
+        "narHash": "sha256-qwcDBtrRvJbrrnv1lf/pREQi8t2hWZxVAyeMo7/E9sw=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "740a22363033e9f1bb6270fbfb5a9574067af15b",
+        "rev": "41c6b421bdc301b2624486e11905c9af7b8ec68e",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`002b92b`](https://github.com/sadjow/codex-cli-nix/commit/002b92b5bc5ff930e5071b275d20453515a495a9) -> [`1639f2d`](https://github.com/sadjow/codex-cli-nix/commit/1639f2d679d181e29a87a49b83d01a5d5cd2a0c6) ([compare](https://github.com/sadjow/codex-cli-nix/compare/002b92b5bc5ff930e5071b275d20453515a495a9...1639f2d679d181e29a87a49b83d01a5d5cd2a0c6))
- `git-hooks-nix`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`5eaaedd`](https://github.com/cachix/git-hooks.nix/commit/5eaaedde414f6eb1aea8b8525c466dc37bba95ae) -> [`6e34e97`](https://github.com/cachix/git-hooks.nix/commit/6e34e97ed9788b17796ee43ccdbaf871a5c2b476) ([compare](https://github.com/cachix/git-hooks.nix/compare/5eaaedde414f6eb1aea8b8525c466dc37bba95ae...6e34e97ed9788b17796ee43ccdbaf871a5c2b476))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`c6ed3ea`](https://github.com/nix-community/home-manager/commit/c6ed3eab64d23520bcbb858aa53fe2b533725d4a) -> [`2a39b08`](https://github.com/nix-community/home-manager/commit/2a39b0828bbffce0d73769a61e46e780488d098b) ([compare](https://github.com/nix-community/home-manager/compare/c6ed3eab64d23520bcbb858aa53fe2b533725d4a...2a39b0828bbffce0d73769a61e46e780488d098b))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`740a223`](https://github.com/nixos/nixos-hardware/commit/740a22363033e9f1bb6270fbfb5a9574067af15b) -> [`41c6b42`](https://github.com/nixos/nixos-hardware/commit/41c6b421bdc301b2624486e11905c9af7b8ec68e) ([compare](https://github.com/nixos/nixos-hardware/compare/740a22363033e9f1bb6270fbfb5a9574067af15b...41c6b421bdc301b2624486e11905c9af7b8ec68e))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`0182a36`](https://github.com/nixos/nixpkgs/commit/0182a361324364ae3f436a63005877674cf45efb) -> [`2fc6539`](https://github.com/nixos/nixpkgs/commit/2fc6539b481e1d2569f25f8799236694180c0993) ([compare](https://github.com/nixos/nixpkgs/compare/0182a361324364ae3f436a63005877674cf45efb...2fc6539b481e1d2569f25f8799236694180c0993))
