### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772152654,
-        "narHash": "sha256-PACE/u1ufOZYOwYfojgOwJlOsoGshVCQb0C6IbiTLN8=",
+        "lastModified": 1772475571,
+        "narHash": "sha256-yXeRqr3YTx7jWGd0VK48+RFoa5izPdPbYZA29rwB3nE=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "1639f2d679d181e29a87a49b83d01a5d5cd2a0c6",
+        "rev": "89ed8d506a74057629c11716eac51717aed9470d",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1772433332,
+        "narHash": "sha256-izhTDFKsg6KeVBxJS9EblGeQ8y+O8eCa6RcW874vxEc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "cf59864ef8aa2e178cccedbe2c178185b0365705",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`1639f2d`](https://github.com/sadjow/codex-cli-nix/commit/1639f2d679d181e29a87a49b83d01a5d5cd2a0c6) -> [`89ed8d5`](https://github.com/sadjow/codex-cli-nix/commit/89ed8d506a74057629c11716eac51717aed9470d) ([compare](https://github.com/sadjow/codex-cli-nix/compare/1639f2d679d181e29a87a49b83d01a5d5cd2a0c6...89ed8d506a74057629c11716eac51717aed9470d))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`dd9b079`](https://github.com/nixos/nixpkgs/commit/dd9b079222d43e1943b6ebd802f04fd959dc8e61) -> [`cf59864`](https://github.com/nixos/nixpkgs/commit/cf59864ef8aa2e178cccedbe2c178185b0365705) ([compare](https://github.com/nixos/nixpkgs/compare/dd9b079222d43e1943b6ebd802f04fd959dc8e61...cf59864ef8aa2e178cccedbe2c178185b0365705))
