### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772475571,
-        "narHash": "sha256-yXeRqr3YTx7jWGd0VK48+RFoa5izPdPbYZA29rwB3nE=",
+        "lastModified": 1772679832,
+        "narHash": "sha256-Osdir489CIBJkcmRcV0if204+tosauqm+Kn6nO3+AIg=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "89ed8d506a74057629c11716eac51717aed9470d",
+        "rev": "fcf491b98303c51bfcb72992aaa546ef4f339123",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772024342,
-        "narHash": "sha256-+eXlIc4/7dE6EcPs9a2DaSY3fTA9AE526hGqkNID3Wg=",
+        "lastModified": 1772665116,
+        "narHash": "sha256-XmjUDG/J8Z8lY5DVNVUf5aoZGc400FxcjsNCqHKiKtc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6e34e97ed9788b17796ee43ccdbaf871a5c2b476",
+        "rev": "39f53203a8458c330f61cc0759fe243f0ac0d198",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772380461,
-        "narHash": "sha256-O3ukj3Bb3V0Tiy/4LUfLlBpWypJ9P0JeUgsKl2nmZZY=",
+        "lastModified": 1772633327,
+        "narHash": "sha256-jl+DJB2DUx7EbWLRng+6HNWW/1/VQOnf0NsQB4PlA7I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f140aa04d7d14f8a50ab27f3691b5766b17ae961",
+        "rev": "5a75730e6f21ee624cbf86f4915c6e7489c74acc",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772433332,
-        "narHash": "sha256-izhTDFKsg6KeVBxJS9EblGeQ8y+O8eCa6RcW874vxEc=",
+        "lastModified": 1772542754,
+        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cf59864ef8aa2e178cccedbe2c178185b0365705",
+        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`89ed8d5`](https://github.com/sadjow/codex-cli-nix/commit/89ed8d506a74057629c11716eac51717aed9470d) -> [`fcf491b`](https://github.com/sadjow/codex-cli-nix/commit/fcf491b98303c51bfcb72992aaa546ef4f339123) ([compare](https://github.com/sadjow/codex-cli-nix/compare/89ed8d506a74057629c11716eac51717aed9470d...fcf491b98303c51bfcb72992aaa546ef4f339123))
- `git-hooks-nix`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`6e34e97`](https://github.com/cachix/git-hooks.nix/commit/6e34e97ed9788b17796ee43ccdbaf871a5c2b476) -> [`39f5320`](https://github.com/cachix/git-hooks.nix/commit/39f53203a8458c330f61cc0759fe243f0ac0d198) ([compare](https://github.com/cachix/git-hooks.nix/compare/6e34e97ed9788b17796ee43ccdbaf871a5c2b476...39f53203a8458c330f61cc0759fe243f0ac0d198))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`f140aa0`](https://github.com/nix-community/home-manager/commit/f140aa04d7d14f8a50ab27f3691b5766b17ae961) -> [`5a75730`](https://github.com/nix-community/home-manager/commit/5a75730e6f21ee624cbf86f4915c6e7489c74acc) ([compare](https://github.com/nix-community/home-manager/compare/f140aa04d7d14f8a50ab27f3691b5766b17ae961...5a75730e6f21ee624cbf86f4915c6e7489c74acc))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`cf59864`](https://github.com/nixos/nixpkgs/commit/cf59864ef8aa2e178cccedbe2c178185b0365705) -> [`8c809a1`](https://github.com/nixos/nixpkgs/commit/8c809a146a140c5c8806f13399592dbcb1bb5dc4) ([compare](https://github.com/nixos/nixpkgs/compare/cf59864ef8aa2e178cccedbe2c178185b0365705...8c809a146a140c5c8806f13399592dbcb1bb5dc4))
