### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772739126,
-        "narHash": "sha256-oHo/EImJ//ZjxV6BmR2RZgo4Jxyubh5mFnFoRYeLzmY=",
+        "lastModified": 1773004139,
+        "narHash": "sha256-K1wp5XjvUiSa4nwdavMaudCCLbr/4eZOKteF1Md4fM0=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "e63f18dfbd22bd0a7c5504be9b7f6a8d3c01488a",
+        "rev": "66895d1bf70a994e66eb5fdc48b2810ef75a1bd2",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772665116,
-        "narHash": "sha256-XmjUDG/J8Z8lY5DVNVUf5aoZGc400FxcjsNCqHKiKtc=",
+        "lastModified": 1772893680,
+        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "39f53203a8458c330f61cc0759fe243f0ac0d198",
+        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772633327,
-        "narHash": "sha256-jl+DJB2DUx7EbWLRng+6HNWW/1/VQOnf0NsQB4PlA7I=",
+        "lastModified": 1772985285,
+        "narHash": "sha256-wEEmvfqJcl9J0wyMgMrj1TixOgInBW/6tLPhWGoZE3s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5a75730e6f21ee624cbf86f4915c6e7489c74acc",
+        "rev": "5be5d8245cbc7bc0c09fbb5f38f23f223c543f85",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772341813,
-        "narHash": "sha256-/PQ0ubBCMj/MVCWEI/XMStn55a8dIKsvztj4ZVLvUrQ=",
+        "lastModified": 1772945408,
+        "narHash": "sha256-PMt48sEQ8cgCeljQ9I/32uoBq/8t8y+7W/nAZhf72TQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a2051ff239ce2e8a0148fa7a152903d9a78e854f",
+        "rev": "1c1d8ea87b047788fd7567adf531418c5da321ec",
         "type": "github"
       },
       "original": {
@@ -237,11 +237,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1771969195,
-        "narHash": "sha256-qwcDBtrRvJbrrnv1lf/pREQi8t2hWZxVAyeMo7/E9sw=",
+        "lastModified": 1772972630,
+        "narHash": "sha256-mUJxsNOrBMNOUJzN0pfdVJ1r2pxeqm9gI/yIKXzVVbk=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "41c6b421bdc301b2624486e11905c9af7b8ec68e",
+        "rev": "3966ce987e1a9a164205ac8259a5fe8a64528f72",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772542754,
-        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`e63f18d`](https://github.com/sadjow/codex-cli-nix/commit/e63f18dfbd22bd0a7c5504be9b7f6a8d3c01488a) -> [`66895d1`](https://github.com/sadjow/codex-cli-nix/commit/66895d1bf70a994e66eb5fdc48b2810ef75a1bd2) ([compare](https://github.com/sadjow/codex-cli-nix/compare/e63f18dfbd22bd0a7c5504be9b7f6a8d3c01488a...66895d1bf70a994e66eb5fdc48b2810ef75a1bd2))
- `git-hooks-nix`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`39f5320`](https://github.com/cachix/git-hooks.nix/commit/39f53203a8458c330f61cc0759fe243f0ac0d198) -> [`8baab58`](https://github.com/cachix/git-hooks.nix/commit/8baab586afc9c9b57645a734c820e4ac0a604af9) ([compare](https://github.com/cachix/git-hooks.nix/compare/39f53203a8458c330f61cc0759fe243f0ac0d198...8baab586afc9c9b57645a734c820e4ac0a604af9))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`5a75730`](https://github.com/nix-community/home-manager/commit/5a75730e6f21ee624cbf86f4915c6e7489c74acc) -> [`5be5d82`](https://github.com/nix-community/home-manager/commit/5be5d8245cbc7bc0c09fbb5f38f23f223c543f85) ([compare](https://github.com/nix-community/home-manager/compare/5a75730e6f21ee624cbf86f4915c6e7489c74acc...5be5d8245cbc7bc0c09fbb5f38f23f223c543f85))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`a2051ff`](https://github.com/Mic92/nix-index-database/commit/a2051ff239ce2e8a0148fa7a152903d9a78e854f) -> [`1c1d8ea`](https://github.com/Mic92/nix-index-database/commit/1c1d8ea87b047788fd7567adf531418c5da321ec) ([compare](https://github.com/Mic92/nix-index-database/compare/a2051ff239ce2e8a0148fa7a152903d9a78e854f...1c1d8ea87b047788fd7567adf531418c5da321ec))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`41c6b42`](https://github.com/nixos/nixos-hardware/commit/41c6b421bdc301b2624486e11905c9af7b8ec68e) -> [`3966ce9`](https://github.com/nixos/nixos-hardware/commit/3966ce987e1a9a164205ac8259a5fe8a64528f72) ([compare](https://github.com/nixos/nixos-hardware/compare/41c6b421bdc301b2624486e11905c9af7b8ec68e...3966ce987e1a9a164205ac8259a5fe8a64528f72))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`8c809a1`](https://github.com/nixos/nixpkgs/commit/8c809a146a140c5c8806f13399592dbcb1bb5dc4) -> [`aca4d95`](https://github.com/nixos/nixpkgs/commit/aca4d95fce4914b3892661bcb80b8087293536c6) ([compare](https://github.com/nixos/nixpkgs/compare/8c809a146a140c5c8806f13399592dbcb1bb5dc4...aca4d95fce4914b3892661bcb80b8087293536c6))
