### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773004139,
-        "narHash": "sha256-K1wp5XjvUiSa4nwdavMaudCCLbr/4eZOKteF1Md4fM0=",
+        "lastModified": 1773189244,
+        "narHash": "sha256-ctI2WntyGzjz7tCcGcG+l+ryV6fJsDvAySPtJH7ia+4=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "66895d1bf70a994e66eb5fdc48b2810ef75a1bd2",
+        "rev": "60da592dbbfceec9adb8b84ea49e88b6663976ae",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772985285,
-        "narHash": "sha256-wEEmvfqJcl9J0wyMgMrj1TixOgInBW/6tLPhWGoZE3s=",
+        "lastModified": 1773422513,
+        "narHash": "sha256-MPjR48roW7CUMU6lu0+qQGqj92Kuh3paIulMWFZy+NQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5be5d8245cbc7bc0c09fbb5f38f23f223c543f85",
+        "rev": "ef12a9a2b0f77c8fa3dda1e7e494fca668909056",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772945408,
-        "narHash": "sha256-PMt48sEQ8cgCeljQ9I/32uoBq/8t8y+7W/nAZhf72TQ=",
+        "lastModified": 1773552174,
+        "narHash": "sha256-mHSRNrT1rjeYBgkAlj07dW3+1nFEgAd8Gu6lgyfT9DU=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "1c1d8ea87b047788fd7567adf531418c5da321ec",
+        "rev": "8faeb68130df077450451b6734a221ba0d6cde42",
         "type": "github"
       },
       "original": {
@@ -237,11 +237,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1772972630,
-        "narHash": "sha256-mUJxsNOrBMNOUJzN0pfdVJ1r2pxeqm9gI/yIKXzVVbk=",
+        "lastModified": 1773533765,
+        "narHash": "sha256-qonGfS2lzCgCl59Zl63jF6dIRRpvW3AJooBGMaXjHiY=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "3966ce987e1a9a164205ac8259a5fe8a64528f72",
+        "rev": "f8e82243fd601afb9f59ad230958bd073795cbfe",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`66895d1`](https://github.com/sadjow/codex-cli-nix/commit/66895d1bf70a994e66eb5fdc48b2810ef75a1bd2) -> [`60da592`](https://github.com/sadjow/codex-cli-nix/commit/60da592dbbfceec9adb8b84ea49e88b6663976ae) ([compare](https://github.com/sadjow/codex-cli-nix/compare/66895d1bf70a994e66eb5fdc48b2810ef75a1bd2...60da592dbbfceec9adb8b84ea49e88b6663976ae))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`5be5d82`](https://github.com/nix-community/home-manager/commit/5be5d8245cbc7bc0c09fbb5f38f23f223c543f85) -> [`ef12a9a`](https://github.com/nix-community/home-manager/commit/ef12a9a2b0f77c8fa3dda1e7e494fca668909056) ([compare](https://github.com/nix-community/home-manager/compare/5be5d8245cbc7bc0c09fbb5f38f23f223c543f85...ef12a9a2b0f77c8fa3dda1e7e494fca668909056))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`1c1d8ea`](https://github.com/Mic92/nix-index-database/commit/1c1d8ea87b047788fd7567adf531418c5da321ec) -> [`8faeb68`](https://github.com/Mic92/nix-index-database/commit/8faeb68130df077450451b6734a221ba0d6cde42) ([compare](https://github.com/Mic92/nix-index-database/compare/1c1d8ea87b047788fd7567adf531418c5da321ec...8faeb68130df077450451b6734a221ba0d6cde42))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`3966ce9`](https://github.com/nixos/nixos-hardware/commit/3966ce987e1a9a164205ac8259a5fe8a64528f72) -> [`f8e8224`](https://github.com/nixos/nixos-hardware/commit/f8e82243fd601afb9f59ad230958bd073795cbfe) ([compare](https://github.com/nixos/nixos-hardware/compare/3966ce987e1a9a164205ac8259a5fe8a64528f72...f8e82243fd601afb9f59ad230958bd073795cbfe))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`aca4d95`](https://github.com/nixos/nixpkgs/commit/aca4d95fce4914b3892661bcb80b8087293536c6) -> [`c06b4ae`](https://github.com/nixos/nixpkgs/commit/c06b4ae3d6599a672a6210b7021d699c351eebda) ([compare](https://github.com/nixos/nixpkgs/compare/aca4d95fce4914b3892661bcb80b8087293536c6...c06b4ae3d6599a672a6210b7021d699c351eebda))
