### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773422513,
-        "narHash": "sha256-MPjR48roW7CUMU6lu0+qQGqj92Kuh3paIulMWFZy+NQ=",
+        "lastModified": 1773608492,
+        "narHash": "sha256-QZteyExJYSQzgxqdsesDPbQgjctGG7iKV/6ooyQPITk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ef12a9a2b0f77c8fa3dda1e7e494fca668909056",
+        "rev": "9a40ec3b78fc688d0908485887d355caa5666d18",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773389992,
-        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
+        "lastModified": 1773520392,
+        "narHash": "sha256-Ra3l8zI7AYwaCxXcU4An8jAC1hhz/TEleXboJhWaBwY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
+        "rev": "f59e980846fe86cd831899cd032fdbd1d6054086",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`ef12a9a`](https://github.com/nix-community/home-manager/commit/ef12a9a2b0f77c8fa3dda1e7e494fca668909056) -> [`9a40ec3`](https://github.com/nix-community/home-manager/commit/9a40ec3b78fc688d0908485887d355caa5666d18) ([compare](https://github.com/nix-community/home-manager/compare/ef12a9a2b0f77c8fa3dda1e7e494fca668909056...9a40ec3b78fc688d0908485887d355caa5666d18))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`c06b4ae`](https://github.com/nixos/nixpkgs/commit/c06b4ae3d6599a672a6210b7021d699c351eebda) -> [`f59e980`](https://github.com/nixos/nixpkgs/commit/f59e980846fe86cd831899cd032fdbd1d6054086) ([compare](https://github.com/nixos/nixpkgs/compare/c06b4ae3d6599a672a6210b7021d699c351eebda...f59e980846fe86cd831899cd032fdbd1d6054086))
