### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773189244,
-        "narHash": "sha256-ctI2WntyGzjz7tCcGcG+l+ryV6fJsDvAySPtJH7ia+4=",
+        "lastModified": 1773944613,
+        "narHash": "sha256-YPgI5DAfcwcWOjHGERsTha/SuuRt7l+oOTGT94G643s=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "60da592dbbfceec9adb8b84ea49e88b6663976ae",
+        "rev": "7937d799ae69e7ded828b8aef5d26e89fbbc817f",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773608492,
-        "narHash": "sha256-QZteyExJYSQzgxqdsesDPbQgjctGG7iKV/6ooyQPITk=",
+        "lastModified": 1773962693,
+        "narHash": "sha256-nf9pgktDE4E2TCavUT1vh3Nd/tfKixL1BK6P32Zp3hI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9a40ec3b78fc688d0908485887d355caa5666d18",
+        "rev": "9d3c1d636e7b8ab10f357cd9bee653cd400437de",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773520392,
-        "narHash": "sha256-Ra3l8zI7AYwaCxXcU4An8jAC1hhz/TEleXboJhWaBwY=",
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f59e980846fe86cd831899cd032fdbd1d6054086",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`60da592`](https://github.com/sadjow/codex-cli-nix/commit/60da592dbbfceec9adb8b84ea49e88b6663976ae) -> [`7937d79`](https://github.com/sadjow/codex-cli-nix/commit/7937d799ae69e7ded828b8aef5d26e89fbbc817f) ([compare](https://github.com/sadjow/codex-cli-nix/compare/60da592dbbfceec9adb8b84ea49e88b6663976ae...7937d799ae69e7ded828b8aef5d26e89fbbc817f))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`9a40ec3`](https://github.com/nix-community/home-manager/commit/9a40ec3b78fc688d0908485887d355caa5666d18) -> [`9d3c1d6`](https://github.com/nix-community/home-manager/commit/9d3c1d636e7b8ab10f357cd9bee653cd400437de) ([compare](https://github.com/nix-community/home-manager/compare/9a40ec3b78fc688d0908485887d355caa5666d18...9d3c1d636e7b8ab10f357cd9bee653cd400437de))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`f59e980`](https://github.com/nixos/nixpkgs/commit/f59e980846fe86cd831899cd032fdbd1d6054086) -> [`b40629e`](https://github.com/nixos/nixpkgs/commit/b40629efe5d6ec48dd1efba650c797ddbd39ace0) ([compare](https://github.com/nixos/nixpkgs/compare/f59e980846fe86cd831899cd032fdbd1d6054086...b40629efe5d6ec48dd1efba650c797ddbd39ace0))
