### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772893680,
-        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
+        "lastModified": 1774104215,
+        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
+        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773962693,
-        "narHash": "sha256-nf9pgktDE4E2TCavUT1vh3Nd/tfKixL1BK6P32Zp3hI=",
+        "lastModified": 1774210133,
+        "narHash": "sha256-yeiWCY9aAUUJ3ebMVjs0UZXRnT5x90MCtpbpOWiXrvM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9d3c1d636e7b8ab10f357cd9bee653cd400437de",
+        "rev": "c6fe2944ad9f2444b2d767c4a5edee7c166e8a95",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773552174,
-        "narHash": "sha256-mHSRNrT1rjeYBgkAlj07dW3+1nFEgAd8Gu6lgyfT9DU=",
+        "lastModified": 1774156144,
+        "narHash": "sha256-gdYe9wTPl4ignDyXUl1LlICWj41+S0GB5lG1fKP17+A=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "8faeb68130df077450451b6734a221ba0d6cde42",
+        "rev": "55b588747fa3d7fc351a11831c4b874dab992862",
         "type": "github"
       },
       "original": {
@@ -237,11 +237,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1773533765,
-        "narHash": "sha256-qonGfS2lzCgCl59Zl63jF6dIRRpvW3AJooBGMaXjHiY=",
+        "lastModified": 1774018263,
+        "narHash": "sha256-HHYEwK1A22aSaxv2ibhMMkKvrDGKGlA/qObG4smrSqc=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "f8e82243fd601afb9f59ad230958bd073795cbfe",
+        "rev": "2d4b4717b2534fad5c715968c1cece04a172b365",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `git-hooks-nix`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`8baab58`](https://github.com/cachix/git-hooks.nix/commit/8baab586afc9c9b57645a734c820e4ac0a604af9) -> [`f799ae9`](https://github.com/cachix/git-hooks.nix/commit/f799ae951fde0627157f40aec28dec27b22076d0) ([compare](https://github.com/cachix/git-hooks.nix/compare/8baab586afc9c9b57645a734c820e4ac0a604af9...f799ae951fde0627157f40aec28dec27b22076d0))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`9d3c1d6`](https://github.com/nix-community/home-manager/commit/9d3c1d636e7b8ab10f357cd9bee653cd400437de) -> [`c6fe294`](https://github.com/nix-community/home-manager/commit/c6fe2944ad9f2444b2d767c4a5edee7c166e8a95) ([compare](https://github.com/nix-community/home-manager/compare/9d3c1d636e7b8ab10f357cd9bee653cd400437de...c6fe2944ad9f2444b2d767c4a5edee7c166e8a95))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`8faeb68`](https://github.com/Mic92/nix-index-database/commit/8faeb68130df077450451b6734a221ba0d6cde42) -> [`55b5887`](https://github.com/Mic92/nix-index-database/commit/55b588747fa3d7fc351a11831c4b874dab992862) ([compare](https://github.com/Mic92/nix-index-database/compare/8faeb68130df077450451b6734a221ba0d6cde42...55b588747fa3d7fc351a11831c4b874dab992862))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`f8e8224`](https://github.com/nixos/nixos-hardware/commit/f8e82243fd601afb9f59ad230958bd073795cbfe) -> [`2d4b471`](https://github.com/nixos/nixos-hardware/commit/2d4b4717b2534fad5c715968c1cece04a172b365) ([compare](https://github.com/nixos/nixos-hardware/compare/f8e82243fd601afb9f59ad230958bd073795cbfe...2d4b4717b2534fad5c715968c1cece04a172b365))
