### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773944613,
-        "narHash": "sha256-YPgI5DAfcwcWOjHGERsTha/SuuRt7l+oOTGT94G643s=",
+        "lastModified": 1774566674,
+        "narHash": "sha256-UVHUY9jHiFj9jqY3KH28OThDEX4JUeEEWIUE+3VFJVI=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "7937d799ae69e7ded828b8aef5d26e89fbbc817f",
+        "rev": "d43a70bd123e49cb862ee36d0e3ab2ed550308df",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774210133,
-        "narHash": "sha256-yeiWCY9aAUUJ3ebMVjs0UZXRnT5x90MCtpbpOWiXrvM=",
+        "lastModified": 1774584114,
+        "narHash": "sha256-uWR9fC+4NykFJVn4GN4Ini9LX+w8Llj7BnWKKp0N6bw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c6fe2944ad9f2444b2d767c4a5edee7c166e8a95",
+        "rev": "4b1be5c38be350ee9452a4847945ce71d950dc31",
         "type": "github"
       },
       "original": {
@@ -237,11 +237,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1774018263,
-        "narHash": "sha256-HHYEwK1A22aSaxv2ibhMMkKvrDGKGlA/qObG4smrSqc=",
+        "lastModified": 1774567711,
+        "narHash": "sha256-uVlOHBvt6Vc/iYNJXLPa4c3cLXwMllOCVfAaLAcphIo=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "2d4b4717b2534fad5c715968c1cece04a172b365",
+        "rev": "3f6f874dfc34d386d10e434c48ad966c4832243e",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773821835,
-        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {
@@ -304,11 +304,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1773041504,
-        "narHash": "sha256-DzUg9H/7DD5ftNZqtQrpvkfF9wcH23uEolAaTVLoVM0=",
+        "lastModified": 1774249419,
+        "narHash": "sha256-hd3C81I/EmJQa8c5MW0aNxtm5ZXTg4QRImgG/ttAV30=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "058e3af38052c4ef3077654f8611bd5e4afcc3b6",
+        "rev": "b4bcda18d123e4ad138af700adbd5b7bfb939c57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`7937d79`](https://github.com/sadjow/codex-cli-nix/commit/7937d799ae69e7ded828b8aef5d26e89fbbc817f) -> [`d43a70b`](https://github.com/sadjow/codex-cli-nix/commit/d43a70bd123e49cb862ee36d0e3ab2ed550308df) ([compare](https://github.com/sadjow/codex-cli-nix/compare/7937d799ae69e7ded828b8aef5d26e89fbbc817f...d43a70bd123e49cb862ee36d0e3ab2ed550308df))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`c6fe294`](https://github.com/nix-community/home-manager/commit/c6fe2944ad9f2444b2d767c4a5edee7c166e8a95) -> [`4b1be5c`](https://github.com/nix-community/home-manager/commit/4b1be5c38be350ee9452a4847945ce71d950dc31) ([compare](https://github.com/nix-community/home-manager/compare/c6fe2944ad9f2444b2d767c4a5edee7c166e8a95...4b1be5c38be350ee9452a4847945ce71d950dc31))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`2d4b471`](https://github.com/nixos/nixos-hardware/commit/2d4b4717b2534fad5c715968c1cece04a172b365) -> [`3f6f874`](https://github.com/nixos/nixos-hardware/commit/3f6f874dfc34d386d10e434c48ad966c4832243e) ([compare](https://github.com/nixos/nixos-hardware/compare/2d4b4717b2534fad5c715968c1cece04a172b365...3f6f874dfc34d386d10e434c48ad966c4832243e))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`b40629e`](https://github.com/nixos/nixpkgs/commit/b40629efe5d6ec48dd1efba650c797ddbd39ace0) -> [`46db2e0`](https://github.com/nixos/nixpkgs/commit/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9) ([compare](https://github.com/nixos/nixpkgs/compare/b40629efe5d6ec48dd1efba650c797ddbd39ace0...46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9))
- `sbomnix`: [`tiiuae/sbomnix`](https://github.com/tiiuae/sbomnix) [`058e3af`](https://github.com/tiiuae/sbomnix/commit/058e3af38052c4ef3077654f8611bd5e4afcc3b6) -> [`b4bcda1`](https://github.com/tiiuae/sbomnix/commit/b4bcda18d123e4ad138af700adbd5b7bfb939c57) ([compare](https://github.com/tiiuae/sbomnix/compare/058e3af38052c4ef3077654f8611bd5e4afcc3b6...b4bcda18d123e4ad138af700adbd5b7bfb939c57))
