### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774584114,
-        "narHash": "sha256-uWR9fC+4NykFJVn4GN4Ini9LX+w8Llj7BnWKKp0N6bw=",
+        "lastModified": 1774647770,
+        "narHash": "sha256-UNNi14XiqRWWjO8ykbFwA5wRwx7EscsC+GItOVpuGjc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4b1be5c38be350ee9452a4847945ce71d950dc31",
+        "rev": "02371c05a04a2876cf92e2d67a259e8f87399068",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`4b1be5c`](https://github.com/nix-community/home-manager/commit/4b1be5c38be350ee9452a4847945ce71d950dc31) -> [`02371c0`](https://github.com/nix-community/home-manager/commit/02371c05a04a2876cf92e2d67a259e8f87399068) ([compare](https://github.com/nix-community/home-manager/compare/4b1be5c38be350ee9452a4847945ce71d950dc31...02371c05a04a2876cf92e2d67a259e8f87399068))
