### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774566674,
-        "narHash": "sha256-UVHUY9jHiFj9jqY3KH28OThDEX4JUeEEWIUE+3VFJVI=",
+        "lastModified": 1774977969,
+        "narHash": "sha256-MbCh0ayUhnP8Z/83tTPR9iTzNxQkfleedmlcgsHh1LA=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "d43a70bd123e49cb862ee36d0e3ab2ed550308df",
+        "rev": "8be597476146c75f440708f9a7ad50ae489641c4",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774104215,
-        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "lastModified": 1774959120,
+        "narHash": "sha256-Pzk6UbueeWy9WFiDY6iA1aHid+2AMzkS6gg2x2cSkz4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "rev": "c06f90f1eb6569bdaf6a4a10cb7e66db4454ac2a",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774647770,
-        "narHash": "sha256-UNNi14XiqRWWjO8ykbFwA5wRwx7EscsC+GItOVpuGjc=",
+        "lastModified": 1774991950,
+        "narHash": "sha256-kScKj3qJDIWuN9/6PMmgy5esrTUkYinrO5VvILik/zw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "02371c05a04a2876cf92e2d67a259e8f87399068",
+        "rev": "f2d3e04e278422c7379e067e323734f3e8c585a7",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774156144,
-        "narHash": "sha256-gdYe9wTPl4ignDyXUl1LlICWj41+S0GB5lG1fKP17+A=",
+        "lastModified": 1774762074,
+        "narHash": "sha256-89Mh4Eb/5stVJX6kGagVMijcU2FmfeD8Qv7UXc5d92o=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "55b588747fa3d7fc351a11831c4b874dab992862",
+        "rev": "bc13aeaed568be76eab84df88ff39261bb52ff70",
         "type": "github"
       },
       "original": {
@@ -237,11 +237,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1774567711,
-        "narHash": "sha256-uVlOHBvt6Vc/iYNJXLPa4c3cLXwMllOCVfAaLAcphIo=",
+        "lastModified": 1774933469,
+        "narHash": "sha256-OrnCQeUO2bqaWUl0lkDWyGWjKsOhtCyd7JSfTedQNUE=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "3f6f874dfc34d386d10e434c48ad966c4832243e",
+        "rev": "f4c4c2c0c923d7811ac2a63ccc154767e4195337",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-codex-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`d43a70b`](https://github.com/sadjow/codex-cli-nix/commit/d43a70bd123e49cb862ee36d0e3ab2ed550308df) -> [`8be5974`](https://github.com/sadjow/codex-cli-nix/commit/8be597476146c75f440708f9a7ad50ae489641c4) ([compare](https://github.com/sadjow/codex-cli-nix/compare/d43a70bd123e49cb862ee36d0e3ab2ed550308df...8be597476146c75f440708f9a7ad50ae489641c4))
- `git-hooks-nix`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`f799ae9`](https://github.com/cachix/git-hooks.nix/commit/f799ae951fde0627157f40aec28dec27b22076d0) -> [`c06f90f`](https://github.com/cachix/git-hooks.nix/commit/c06f90f1eb6569bdaf6a4a10cb7e66db4454ac2a) ([compare](https://github.com/cachix/git-hooks.nix/compare/f799ae951fde0627157f40aec28dec27b22076d0...c06f90f1eb6569bdaf6a4a10cb7e66db4454ac2a))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`02371c0`](https://github.com/nix-community/home-manager/commit/02371c05a04a2876cf92e2d67a259e8f87399068) -> [`f2d3e04`](https://github.com/nix-community/home-manager/commit/f2d3e04e278422c7379e067e323734f3e8c585a7) ([compare](https://github.com/nix-community/home-manager/compare/02371c05a04a2876cf92e2d67a259e8f87399068...f2d3e04e278422c7379e067e323734f3e8c585a7))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`55b5887`](https://github.com/Mic92/nix-index-database/commit/55b588747fa3d7fc351a11831c4b874dab992862) -> [`bc13aea`](https://github.com/Mic92/nix-index-database/commit/bc13aeaed568be76eab84df88ff39261bb52ff70) ([compare](https://github.com/Mic92/nix-index-database/compare/55b588747fa3d7fc351a11831c4b874dab992862...bc13aeaed568be76eab84df88ff39261bb52ff70))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`3f6f874`](https://github.com/nixos/nixos-hardware/commit/3f6f874dfc34d386d10e434c48ad966c4832243e) -> [`f4c4c2c`](https://github.com/nixos/nixos-hardware/commit/f4c4c2c0c923d7811ac2a63ccc154767e4195337) ([compare](https://github.com/nixos/nixos-hardware/compare/3f6f874dfc34d386d10e434c48ad966c4832243e...f4c4c2c0c923d7811ac2a63ccc154767e4195337))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`46db2e0`](https://github.com/nixos/nixpkgs/commit/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9) -> [`8110df5`](https://github.com/nixos/nixpkgs/commit/8110df5ad7abf5d4c0f6fb0f8f978390e77f9685) ([compare](https://github.com/nixos/nixpkgs/compare/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9...8110df5ad7abf5d4c0f6fb0f8f978390e77f9685))
