### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775143651,
-        "narHash": "sha256-S0RqAyDPMTcv9vASMaE8eY1QexFysAOdnxUxFHIPOyE=",
+        "lastModified": 1775268934,
+        "narHash": "sha256-Sa5tW5kYPJornQEkFVD43F/0d4/WP+/GLTNktTFe2qU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d166a078541982a76f14d3e06e9665fa5c9ed85e",
+        "rev": "9dc93220c1c9a410ef6277d6dc55c571d9e592d0",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775171219,
-        "narHash": "sha256-3poVYyTB/THwwX2OIA4YNTEhg5pW3XEt1l53GV0j2mk=",
+        "lastModified": 1775261198,
+        "narHash": "sha256-BdXWR+LoP8K0V71oT1pNXdlajowVxaLiXXeDXMdvLoM=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "644838d512a95c415886736f1e6dc28531625f7d",
+        "rev": "e4ec05a124e6a206e405091f245449291c58e8b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`d166a07`](https://github.com/nix-community/home-manager/commit/d166a078541982a76f14d3e06e9665fa5c9ed85e) -> [`9dc9322`](https://github.com/nix-community/home-manager/commit/9dc93220c1c9a410ef6277d6dc55c571d9e592d0) ([compare](https://github.com/nix-community/home-manager/compare/d166a078541982a76f14d3e06e9665fa5c9ed85e...9dc93220c1c9a410ef6277d6dc55c571d9e592d0))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`644838d`](https://github.com/ryoppippi/nix-claude-code/commit/644838d512a95c415886736f1e6dc28531625f7d) -> [`e4ec05a`](https://github.com/ryoppippi/nix-claude-code/commit/e4ec05a124e6a206e405091f245449291c58e8b6) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/644838d512a95c415886736f1e6dc28531625f7d...e4ec05a124e6a206e405091f245449291c58e8b6))
