### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775036584,
-        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775268934,
-        "narHash": "sha256-Sa5tW5kYPJornQEkFVD43F/0d4/WP+/GLTNktTFe2qU=",
+        "lastModified": 1775683737,
+        "narHash": "sha256-oBYyowo6yfgb95Z78s3uTnAd9KkpJpwzjJbfnpLaM2Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9dc93220c1c9a410ef6277d6dc55c571d9e592d0",
+        "rev": "7ba4ee4228ed36123c7cb75d50524b43514ef992",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775261198,
-        "narHash": "sha256-BdXWR+LoP8K0V71oT1pNXdlajowVxaLiXXeDXMdvLoM=",
+        "lastModified": 1775702549,
+        "narHash": "sha256-33oPZsvyI41U8ygJbzgb6+GkyAaKEyVUQ3VcFNckeJY=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "e4ec05a124e6a206e405091f245449291c58e8b6",
+        "rev": "729a851a87d66cebc50953e9509602e28ecb9520",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774762074,
-        "narHash": "sha256-89Mh4Eb/5stVJX6kGagVMijcU2FmfeD8Qv7UXc5d92o=",
+        "lastModified": 1775365369,
+        "narHash": "sha256-DgH5mveLoau20CuTnaU5RXZWgFQWn56onQ4Du2CqYoI=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "bc13aeaed568be76eab84df88ff39261bb52ff70",
+        "rev": "cef5cf82671e749ac87d69aadecbb75967e6f6c3",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1775203647,
-        "narHash": "sha256-6MWaMLXK9QMndI94CIxeiPafi3wuO+imCtK9tfhsZdw=",
+        "lastModified": 1775490113,
+        "narHash": "sha256-2ZBhDNZZwYkRmefK5XLOusCJHnoeKkoN95hoSGgMxWM=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "80afbd13eea0b7c4ac188de949e1711b31c2b5f0",
+        "rev": "c775c2772ba56e906cbeb4e0b2db19079ef11ff7",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `git-hooks-nix`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`4e0eb04`](https://github.com/cachix/git-hooks.nix/commit/4e0eb042b67d863b1b34b3f64d52ceb9cd926735) -> [`580633f`](https://github.com/cachix/git-hooks.nix/commit/580633fa3fe5fc0379905986543fd7495481913d) ([compare](https://github.com/cachix/git-hooks.nix/compare/4e0eb042b67d863b1b34b3f64d52ceb9cd926735...580633fa3fe5fc0379905986543fd7495481913d))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`9dc9322`](https://github.com/nix-community/home-manager/commit/9dc93220c1c9a410ef6277d6dc55c571d9e592d0) -> [`7ba4ee4`](https://github.com/nix-community/home-manager/commit/7ba4ee4228ed36123c7cb75d50524b43514ef992) ([compare](https://github.com/nix-community/home-manager/compare/9dc93220c1c9a410ef6277d6dc55c571d9e592d0...7ba4ee4228ed36123c7cb75d50524b43514ef992))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`e4ec05a`](https://github.com/ryoppippi/nix-claude-code/commit/e4ec05a124e6a206e405091f245449291c58e8b6) -> [`729a851`](https://github.com/ryoppippi/nix-claude-code/commit/729a851a87d66cebc50953e9509602e28ecb9520) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/e4ec05a124e6a206e405091f245449291c58e8b6...729a851a87d66cebc50953e9509602e28ecb9520))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`bc13aea`](https://github.com/Mic92/nix-index-database/commit/bc13aeaed568be76eab84df88ff39261bb52ff70) -> [`cef5cf8`](https://github.com/Mic92/nix-index-database/commit/cef5cf82671e749ac87d69aadecbb75967e6f6c3) ([compare](https://github.com/Mic92/nix-index-database/compare/bc13aeaed568be76eab84df88ff39261bb52ff70...cef5cf82671e749ac87d69aadecbb75967e6f6c3))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`80afbd1`](https://github.com/nixos/nixos-hardware/commit/80afbd13eea0b7c4ac188de949e1711b31c2b5f0) -> [`c775c27`](https://github.com/nixos/nixos-hardware/commit/c775c2772ba56e906cbeb4e0b2db19079ef11ff7) ([compare](https://github.com/nixos/nixos-hardware/compare/80afbd13eea0b7c4ac188de949e1711b31c2b5f0...c775c2772ba56e906cbeb4e0b2db19079ef11ff7))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`6201e20`](https://github.com/nixos/nixpkgs/commit/6201e203d09599479a3b3450ed24fa81537ebc4e) -> [`68d8aa3`](https://github.com/nixos/nixpkgs/commit/68d8aa3d661f0e6bd5862291b5bb263b2a6595c9) ([compare](https://github.com/nixos/nixpkgs/compare/6201e203d09599479a3b3450ed24fa81537ebc4e...68d8aa3d661f0e6bd5862291b5bb263b2a6595c9))
