### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774977969,
-        "narHash": "sha256-MbCh0ayUhnP8Z/83tTPR9iTzNxQkfleedmlcgsHh1LA=",
+        "lastModified": 1775882637,
+        "narHash": "sha256-e2jaiMpQr2N/AxhRqt1NA0DU7jC9Sv0pvNnpCuyXxuw=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "8be597476146c75f440708f9a7ad50ae489641c4",
+        "rev": "d4223ed9ee52efe572c1612579c3c6a80bc4d8db",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775683737,
-        "narHash": "sha256-oBYyowo6yfgb95Z78s3uTnAd9KkpJpwzjJbfnpLaM2Y=",
+        "lastModified": 1775900011,
+        "narHash": "sha256-QUGu6CJYFQ5AWVV0n3/FsJyV+1/gj7HSDx68/SX9pwM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7ba4ee4228ed36123c7cb75d50524b43514ef992",
+        "rev": "b0569dc6ec1e6e7fefd8f6897184e4c191cd768e",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775702549,
-        "narHash": "sha256-33oPZsvyI41U8ygJbzgb6+GkyAaKEyVUQ3VcFNckeJY=",
+        "lastModified": 1775962723,
+        "narHash": "sha256-9+/hGLiAF8ivshgYJKeq9aP47bhgdezoZ3L89qglPH8=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "729a851a87d66cebc50953e9509602e28ecb9520",
+        "rev": "20516bb296330728a9d044797046a149dd291534",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`8be5974`](https://github.com/sadjow/codex-cli-nix/commit/8be597476146c75f440708f9a7ad50ae489641c4) -> [`d4223ed`](https://github.com/sadjow/codex-cli-nix/commit/d4223ed9ee52efe572c1612579c3c6a80bc4d8db) ([compare](https://github.com/sadjow/codex-cli-nix/compare/8be597476146c75f440708f9a7ad50ae489641c4...d4223ed9ee52efe572c1612579c3c6a80bc4d8db))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`7ba4ee4`](https://github.com/nix-community/home-manager/commit/7ba4ee4228ed36123c7cb75d50524b43514ef992) -> [`b0569dc`](https://github.com/nix-community/home-manager/commit/b0569dc6ec1e6e7fefd8f6897184e4c191cd768e) ([compare](https://github.com/nix-community/home-manager/compare/7ba4ee4228ed36123c7cb75d50524b43514ef992...b0569dc6ec1e6e7fefd8f6897184e4c191cd768e))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`729a851`](https://github.com/ryoppippi/nix-claude-code/commit/729a851a87d66cebc50953e9509602e28ecb9520) -> [`20516bb`](https://github.com/ryoppippi/nix-claude-code/commit/20516bb296330728a9d044797046a149dd291534) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/729a851a87d66cebc50953e9509602e28ecb9520...20516bb296330728a9d044797046a149dd291534))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`68d8aa3`](https://github.com/nixos/nixpkgs/commit/68d8aa3d661f0e6bd5862291b5bb263b2a6595c9) -> [`4c1018d`](https://github.com/nixos/nixpkgs/commit/4c1018dae018162ec878d42fec712642d214fdfa) ([compare](https://github.com/nixos/nixpkgs/compare/68d8aa3d661f0e6bd5862291b5bb263b2a6595c9...4c1018dae018162ec878d42fec712642d214fdfa))
