### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775900011,
-        "narHash": "sha256-QUGu6CJYFQ5AWVV0n3/FsJyV+1/gj7HSDx68/SX9pwM=",
+        "lastModified": 1776136611,
+        "narHash": "sha256-b2pu3Pb28W0bJzQVP3OJHZC5+dgOOeqjlli2WVakKEU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b0569dc6ec1e6e7fefd8f6897184e4c191cd768e",
+        "rev": "8a423e444b17dde406097328604a64fc7429e34e",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775962723,
-        "narHash": "sha256-9+/hGLiAF8ivshgYJKeq9aP47bhgdezoZ3L89qglPH8=",
+        "lastModified": 1776111353,
+        "narHash": "sha256-z7K56qxxDuBJHVimRpLfKVecnqjgt0zLz/itIW92pyk=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "20516bb296330728a9d044797046a149dd291534",
+        "rev": "d95976f429a474627459f5d3b6dadaf4941cd71e",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775365369,
-        "narHash": "sha256-DgH5mveLoau20CuTnaU5RXZWgFQWn56onQ4Du2CqYoI=",
+        "lastModified": 1775970782,
+        "narHash": "sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "cef5cf82671e749ac87d69aadecbb75967e6f6c3",
+        "rev": "bedba5989b04614fc598af9633033b95a937933f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`b0569dc`](https://github.com/nix-community/home-manager/commit/b0569dc6ec1e6e7fefd8f6897184e4c191cd768e) -> [`8a423e4`](https://github.com/nix-community/home-manager/commit/8a423e444b17dde406097328604a64fc7429e34e) ([compare](https://github.com/nix-community/home-manager/compare/b0569dc6ec1e6e7fefd8f6897184e4c191cd768e...8a423e444b17dde406097328604a64fc7429e34e))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`20516bb`](https://github.com/ryoppippi/nix-claude-code/commit/20516bb296330728a9d044797046a149dd291534) -> [`d95976f`](https://github.com/ryoppippi/nix-claude-code/commit/d95976f429a474627459f5d3b6dadaf4941cd71e) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/20516bb296330728a9d044797046a149dd291534...d95976f429a474627459f5d3b6dadaf4941cd71e))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`cef5cf8`](https://github.com/Mic92/nix-index-database/commit/cef5cf82671e749ac87d69aadecbb75967e6f6c3) -> [`bedba59`](https://github.com/Mic92/nix-index-database/commit/bedba5989b04614fc598af9633033b95a937933f) ([compare](https://github.com/Mic92/nix-index-database/compare/cef5cf82671e749ac87d69aadecbb75967e6f6c3...bedba5989b04614fc598af9633033b95a937933f))
