### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776136611,
-        "narHash": "sha256-b2pu3Pb28W0bJzQVP3OJHZC5+dgOOeqjlli2WVakKEU=",
+        "lastModified": 1776184304,
+        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a423e444b17dde406097328604a64fc7429e34e",
+        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776111353,
-        "narHash": "sha256-z7K56qxxDuBJHVimRpLfKVecnqjgt0zLz/itIW92pyk=",
+        "lastModified": 1776225929,
+        "narHash": "sha256-HHhjMR3XLLkVfsyoHEd42aVqbHCHcN+LT4ibeBNWemk=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "d95976f429a474627459f5d3b6dadaf4941cd71e",
+        "rev": "7d61370a82bb8cf070d8cd0c93f0b6877075b7c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`8a423e4`](https://github.com/nix-community/home-manager/commit/8a423e444b17dde406097328604a64fc7429e34e) -> [`3c7524c`](https://github.com/nix-community/home-manager/commit/3c7524c68348ef79ce48308e0978611a050089b2) ([compare](https://github.com/nix-community/home-manager/compare/8a423e444b17dde406097328604a64fc7429e34e...3c7524c68348ef79ce48308e0978611a050089b2))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`d95976f`](https://github.com/ryoppippi/nix-claude-code/commit/d95976f429a474627459f5d3b6dadaf4941cd71e) -> [`7d61370`](https://github.com/ryoppippi/nix-claude-code/commit/7d61370a82bb8cf070d8cd0c93f0b6877075b7c3) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/d95976f429a474627459f5d3b6dadaf4941cd71e...7d61370a82bb8cf070d8cd0c93f0b6877075b7c3))
