### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775882637,
-        "narHash": "sha256-e2jaiMpQr2N/AxhRqt1NA0DU7jC9Sv0pvNnpCuyXxuw=",
+        "lastModified": 1776288174,
+        "narHash": "sha256-kCvsC6JxJtcpLLPrrjptgmBlV7Zmz0NWdLfoP15+jOc=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "d4223ed9ee52efe572c1612579c3c6a80bc4d8db",
+        "rev": "7c050fa951b5ca20a4754b42ec5242231edda35f",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776184304,
-        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
+        "lastModified": 1776454077,
+        "narHash": "sha256-7zSUFWsU0+jlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
+        "rev": "565e5349208fe7d0831ef959103c9bafbeac0681",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776225929,
-        "narHash": "sha256-HHhjMR3XLLkVfsyoHEd42aVqbHCHcN+LT4ibeBNWemk=",
+        "lastModified": 1776470992,
+        "narHash": "sha256-IT3l27UrqC8630DruPMwBbgy8+en3DYMBEU6Mmd+cC0=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "7d61370a82bb8cf070d8cd0c93f0b6877075b7c3",
+        "rev": "3ea6392c9563b0a7f7820e82faffdb075676f9d8",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1774249419,
-        "narHash": "sha256-hd3C81I/EmJQa8c5MW0aNxtm5ZXTg4QRImgG/ttAV30=",
+        "lastModified": 1776416795,
+        "narHash": "sha256-v/7mMaluhnMBzqALRYErxywWFV1+76m0SUDFXdTw/ng=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "b4bcda18d123e4ad138af700adbd5b7bfb939c57",
+        "rev": "d4bb176aa4a92033e5e7d531fca33be83763ceee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`d4223ed`](https://github.com/sadjow/codex-cli-nix/commit/d4223ed9ee52efe572c1612579c3c6a80bc4d8db) -> [`7c050fa`](https://github.com/sadjow/codex-cli-nix/commit/7c050fa951b5ca20a4754b42ec5242231edda35f) ([compare](https://github.com/sadjow/codex-cli-nix/compare/d4223ed9ee52efe572c1612579c3c6a80bc4d8db...7c050fa951b5ca20a4754b42ec5242231edda35f))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`3c7524c`](https://github.com/nix-community/home-manager/commit/3c7524c68348ef79ce48308e0978611a050089b2) -> [`565e534`](https://github.com/nix-community/home-manager/commit/565e5349208fe7d0831ef959103c9bafbeac0681) ([compare](https://github.com/nix-community/home-manager/compare/3c7524c68348ef79ce48308e0978611a050089b2...565e5349208fe7d0831ef959103c9bafbeac0681))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`7d61370`](https://github.com/ryoppippi/nix-claude-code/commit/7d61370a82bb8cf070d8cd0c93f0b6877075b7c3) -> [`3ea6392`](https://github.com/ryoppippi/nix-claude-code/commit/3ea6392c9563b0a7f7820e82faffdb075676f9d8) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/7d61370a82bb8cf070d8cd0c93f0b6877075b7c3...3ea6392c9563b0a7f7820e82faffdb075676f9d8))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`4c1018d`](https://github.com/nixos/nixpkgs/commit/4c1018dae018162ec878d42fec712642d214fdfa) -> [`4bd9165`](https://github.com/nixos/nixpkgs/commit/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9) ([compare](https://github.com/nixos/nixpkgs/compare/4c1018dae018162ec878d42fec712642d214fdfa...4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9))
- `sbomnix`: [`tiiuae/sbomnix`](https://github.com/tiiuae/sbomnix) [`b4bcda1`](https://github.com/tiiuae/sbomnix/commit/b4bcda18d123e4ad138af700adbd5b7bfb939c57) -> [`d4bb176`](https://github.com/tiiuae/sbomnix/commit/d4bb176aa4a92033e5e7d531fca33be83763ceee) ([compare](https://github.com/tiiuae/sbomnix/compare/b4bcda18d123e4ad138af700adbd5b7bfb939c57...d4bb176aa4a92033e5e7d531fca33be83763ceee))
