### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776454077,
-        "narHash": "sha256-7zSUFWsU0+jlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk=",
+        "lastModified": 1776660580,
+        "narHash": "sha256-7G9CenNTI1qomeEqsXHiGctpcZbIPbskGqrO2ZEQDn0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "565e5349208fe7d0831ef959103c9bafbeac0681",
+        "rev": "1ab3a4b78ebbf13d4ae786180bc8b7de9741cf30",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775970782,
-        "narHash": "sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk=",
+        "lastModified": 1776575850,
+        "narHash": "sha256-28Gqz0GDpGsBv8GtAn2dywEQRr+CtTDsD5J7VD6icBE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "bedba5989b04614fc598af9633033b95a937933f",
+        "rev": "3b9653a107c736222b5ae0d4036dd3b885219065",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`565e534`](https://github.com/nix-community/home-manager/commit/565e5349208fe7d0831ef959103c9bafbeac0681) -> [`1ab3a4b`](https://github.com/nix-community/home-manager/commit/1ab3a4b78ebbf13d4ae786180bc8b7de9741cf30) ([compare](https://github.com/nix-community/home-manager/compare/565e5349208fe7d0831ef959103c9bafbeac0681...1ab3a4b78ebbf13d4ae786180bc8b7de9741cf30))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`bedba59`](https://github.com/Mic92/nix-index-database/commit/bedba5989b04614fc598af9633033b95a937933f) -> [`3b9653a`](https://github.com/Mic92/nix-index-database/commit/3b9653a107c736222b5ae0d4036dd3b885219065) ([compare](https://github.com/Mic92/nix-index-database/compare/bedba5989b04614fc598af9633033b95a937933f...3b9653a107c736222b5ae0d4036dd3b885219065))
