### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777054843,
-        "narHash": "sha256-aiuiKK6xJu5inj/RTmSl9S3jDC6RzNsKfNJ700MRPNY=",
+        "lastModified": 1777661972,
+        "narHash": "sha256-VmcoQGZ3BNFlsI2jKUQH33MvEgkU6pvdxq4tofVLgmo=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "fc382bef14dcb9873769bdcb4d3b943ef2606489",
+        "rev": "828b885b1be90991a2bd1087f2afd722476bfaed",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1746162366,
-        "narHash": "sha256-5SSSZ/oQkwfcAz/o/6TlejlVGqeK08wyREBQ5qFFPhM=",
+        "lastModified": 1761640442,
+        "narHash": "sha256-AtrEP6Jmdvrqiv4x2xa5mrtaIp3OEe8uBYCDZDS+hu8=",
         "owner": "nix-community",
         "repo": "flake-compat",
-        "rev": "0f158086a2ecdbb138cd0429410e44994f1b7e4b",
+        "rev": "4a56054d8ffc173222d09dad23adf4ba946c8884",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1760948891,
-        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760663237,
-        "narHash": "sha256-BflA6U4AM1bzuRMR8QqzPXqh8sWVCNDzOdsxXEguJIc=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777086106,
-        "narHash": "sha256-hlNpIN18pw3xo34Lsrp6vAMUPn0aB/zFBqL0QXI1Pmk=",
+        "lastModified": 1777780644,
+        "narHash": "sha256-CYpc+mk28rmcQWGygeM8CA+Z8SZYy8BOyQtiW18spao=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5826802354a74af18540aef0b01bc1320f82cc17",
+        "rev": "b9311028044a9e9b2cf27db15ef0a87d464e212d",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777072284,
-        "narHash": "sha256-LSPT8NDDgIxagZJiOQyVzHwXO5MEy8Kdze3wXwDbcfY=",
+        "lastModified": 1777583893,
+        "narHash": "sha256-ziYsU6RFXdnJNOZpp39Op9TgFYIG3md89KOdPZi9lH4=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "320f208e33fc5375e0789243ff56bb168c5972ef",
+        "rev": "90a39a32b51501c1ae3af6918c1bcea2415ce345",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776829403,
-        "narHash": "sha256-oHVcvP2Ahhj1KUsEzp+2BQF55/r5VSa3QxdPdwE1p00=",
+        "lastModified": 1777181277,
+        "narHash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "c43246d4e9e506178b69baed075d797ec2d873e2",
+        "rev": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -288,11 +288,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
@@ -322,15 +322,14 @@
         "git-hooks-nix": "git-hooks-nix_2",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "treefmt-nix": "treefmt-nix"
+        ]
       },
       "locked": {
-        "lastModified": 1777091282,
-        "narHash": "sha256-p4kXI58Q1aRzAWlgvj2Zp5G8dUvQ3tkj32ewl2XnNiU=",
+        "lastModified": 1777550525,
+        "narHash": "sha256-W+KWJxj7TVdOynvzRxnLLygkorkQaL6PCyTA4bF76AU=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "eeeff72c15f9e104e72d364d90a41d969589fc4b",
+        "rev": "f684e6b971b086e2510025d6fbb75dc068d00a57",
         "type": "github"
       },
       "original": {
@@ -346,11 +345,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776771786,
-        "narHash": "sha256-DRFGPfFV6hbrfO9a1PH1FkCi7qR5FgjSqsQGGvk1rdI=",
+        "lastModified": 1777338324,
+        "narHash": "sha256-bc+ZZCmOTNq86/svGnw0tVpH7vJaLYvGLLKFYP08Q8E=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "bef289e2248991f7afeb95965c82fbcd8ff72598",
+        "rev": "8eaee5c45428b28b8c47a83e4c09dccec5f279b5",
         "type": "github"
       },
       "original": {
@@ -371,27 +370,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "sbomnix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1760945191,
-        "narHash": "sha256-ZRVs8UqikBa4Ki3X4KCnMBtBW0ux1DaT35tgsnB1jM4=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "f56b1934f5f8fcab8deb5d38d42fd692632b47c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     }


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`fc382be`](https://github.com/sadjow/codex-cli-nix/commit/fc382bef14dcb9873769bdcb4d3b943ef2606489) -> [`828b885`](https://github.com/sadjow/codex-cli-nix/commit/828b885b1be90991a2bd1087f2afd722476bfaed) ([compare](https://github.com/sadjow/codex-cli-nix/compare/fc382bef14dcb9873769bdcb4d3b943ef2606489...828b885b1be90991a2bd1087f2afd722476bfaed))
- `flake-compat_2`: [`nix-community/flake-compat`](https://github.com/nix-community/flake-compat) [`0f15808`](https://github.com/nix-community/flake-compat/commit/0f158086a2ecdbb138cd0429410e44994f1b7e4b) -> [`4a56054`](https://github.com/nix-community/flake-compat/commit/4a56054d8ffc173222d09dad23adf4ba946c8884) ([compare](https://github.com/nix-community/flake-compat/compare/0f158086a2ecdbb138cd0429410e44994f1b7e4b...4a56054d8ffc173222d09dad23adf4ba946c8884))
- `flake-parts`: [`hercules-ci/flake-parts`](https://github.com/hercules-ci/flake-parts) [`8645992`](https://github.com/hercules-ci/flake-parts/commit/864599284fc7c0ba6357ed89ed5e2cd5040f0c04) -> [`3107b77`](https://github.com/hercules-ci/flake-parts/commit/3107b77cd68437b9a76194f0f7f9c55f2329ca5b) ([compare](https://github.com/hercules-ci/flake-parts/compare/864599284fc7c0ba6357ed89ed5e2cd5040f0c04...3107b77cd68437b9a76194f0f7f9c55f2329ca5b))
- `git-hooks-nix_2`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`ca5b894`](https://github.com/cachix/git-hooks.nix/commit/ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37) -> [`3cfd774`](https://github.com/cachix/git-hooks.nix/commit/3cfd774b0a530725a077e17354fbdb87ea1c4aad) ([compare](https://github.com/cachix/git-hooks.nix/compare/ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37...3cfd774b0a530725a077e17354fbdb87ea1c4aad))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`5826802`](https://github.com/nix-community/home-manager/commit/5826802354a74af18540aef0b01bc1320f82cc17) -> [`b931102`](https://github.com/nix-community/home-manager/commit/b9311028044a9e9b2cf27db15ef0a87d464e212d) ([compare](https://github.com/nix-community/home-manager/compare/5826802354a74af18540aef0b01bc1320f82cc17...b9311028044a9e9b2cf27db15ef0a87d464e212d))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`320f208`](https://github.com/ryoppippi/nix-claude-code/commit/320f208e33fc5375e0789243ff56bb168c5972ef) -> [`90a39a3`](https://github.com/ryoppippi/nix-claude-code/commit/90a39a32b51501c1ae3af6918c1bcea2415ce345) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/320f208e33fc5375e0789243ff56bb168c5972ef...90a39a32b51501c1ae3af6918c1bcea2415ce345))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`c43246d`](https://github.com/Mic92/nix-index-database/commit/c43246d4e9e506178b69baed075d797ec2d873e2) -> [`b8eb7ac`](https://github.com/Mic92/nix-index-database/commit/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa) ([compare](https://github.com/Mic92/nix-index-database/compare/c43246d4e9e506178b69baed075d797ec2d873e2...b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`0726a0e`](https://github.com/nixos/nixpkgs/commit/0726a0ecb6d4e08f6adced58726b95db924cef57) -> [`15f4ee4`](https://github.com/nixos/nixpkgs/commit/15f4ee454b1dce334612fa6843b3e05cf546efab) ([compare](https://github.com/nixos/nixpkgs/compare/0726a0ecb6d4e08f6adced58726b95db924cef57...15f4ee454b1dce334612fa6843b3e05cf546efab))
- `nixpkgs-lib`: [`nix-community/nixpkgs.lib`](https://github.com/nix-community/nixpkgs.lib) [`a73b9c7`](https://github.com/nix-community/nixpkgs.lib/commit/a73b9c743612e4244d865a2fdee11865283c04e6) -> [`333c4e0`](https://github.com/nix-community/nixpkgs.lib/commit/333c4e0545a6da976206c74db8773a1645b5870a) ([compare](https://github.com/nix-community/nixpkgs.lib/compare/a73b9c743612e4244d865a2fdee11865283c04e6...333c4e0545a6da976206c74db8773a1645b5870a))
- `sbomnix`: [`tiiuae/sbomnix`](https://github.com/tiiuae/sbomnix) [`eeeff72`](https://github.com/tiiuae/sbomnix/commit/eeeff72c15f9e104e72d364d90a41d969589fc4b) -> [`f684e6b`](https://github.com/tiiuae/sbomnix/commit/f684e6b971b086e2510025d6fbb75dc068d00a57) ([compare](https://github.com/tiiuae/sbomnix/compare/eeeff72c15f9e104e72d364d90a41d969589fc4b...f684e6b971b086e2510025d6fbb75dc068d00a57))
- `sops-nix`: [`Mic92/sops-nix`](https://github.com/Mic92/sops-nix) [`bef289e`](https://github.com/Mic92/sops-nix/commit/bef289e2248991f7afeb95965c82fbcd8ff72598) -> [`8eaee5c`](https://github.com/Mic92/sops-nix/commit/8eaee5c45428b28b8c47a83e4c09dccec5f279b5) ([compare](https://github.com/Mic92/sops-nix/compare/bef289e2248991f7afeb95965c82fbcd8ff72598...8eaee5c45428b28b8c47a83e4c09dccec5f279b5))
