### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777661972,
-        "narHash": "sha256-VmcoQGZ3BNFlsI2jKUQH33MvEgkU6pvdxq4tofVLgmo=",
+        "lastModified": 1778175487,
+        "narHash": "sha256-eBoHv4Ha4Phyqc1BibguvgebYHNIdB1lYNDc5tdmw0M=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "828b885b1be90991a2bd1087f2afd722476bfaed",
+        "rev": "84ef41fa58a1731da7e2d9856f8358cdbec8f6e3",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780644,
-        "narHash": "sha256-CYpc+mk28rmcQWGygeM8CA+Z8SZYy8BOyQtiW18spao=",
+        "lastModified": 1778144356,
+        "narHash": "sha256-dGM+QCstz/DyLB68+JK5GWyMx4QSqmOJEVgZmy63d/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b9311028044a9e9b2cf27db15ef0a87d464e212d",
+        "rev": "e4419d3123b780d5f4c0bceeace450424387638c",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777583893,
-        "narHash": "sha256-ziYsU6RFXdnJNOZpp39Op9TgFYIG3md89KOdPZi9lH4=",
+        "lastModified": 1778185472,
+        "narHash": "sha256-sKqHj01e/OMmvzFOyhpHHmUPArzZNrFOrmGvepDZtIY=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "90a39a32b51501c1ae3af6918c1bcea2415ce345",
+        "rev": "ffd7ac55d04a57083aa421d6598235127a7faf38",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777181277,
-        "narHash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=",
+        "lastModified": 1777787189,
+        "narHash": "sha256-2KUbS/HhzWW3kkkY1+RiWj9mJ76VEXw8lBJzcCFKzfY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
+        "rev": "2dea2b920e7127b3afa8506713f23536651de312",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1776983936,
-        "narHash": "sha256-ZOQyNqSvJ8UdrrqU1p7vaFcdL53idK+LOM8oRWEWh6o=",
+        "lastModified": 1778143761,
+        "narHash": "sha256-lkesY6x2X2qxlqLM7CT2iM/0rP2JB7fruPN3h8POXmI=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "2096f3f411ce46e88a79ae4eafcfc9df8ed41c61",
+        "rev": "3bcaa367d4c550d687a17ac792fd5cda214ee871",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777550525,
-        "narHash": "sha256-W+KWJxj7TVdOynvzRxnLLygkorkQaL6PCyTA4bF76AU=",
+        "lastModified": 1777832975,
+        "narHash": "sha256-wqW8szTu6SvkFaLjLW584iTKdndxtByJ9b7hK7UFZjg=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "f684e6b971b086e2510025d6fbb75dc068d00a57",
+        "rev": "6fb9c6707ff33f904213550ec18aac1d346d36af",
         "type": "github"
       },
       "original": {
@@ -345,11 +345,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777338324,
-        "narHash": "sha256-bc+ZZCmOTNq86/svGnw0tVpH7vJaLYvGLLKFYP08Q8E=",
+        "lastModified": 1777944972,
+        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8eaee5c45428b28b8c47a83e4c09dccec5f279b5",
+        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`828b885`](https://github.com/sadjow/codex-cli-nix/commit/828b885b1be90991a2bd1087f2afd722476bfaed) -> [`84ef41f`](https://github.com/sadjow/codex-cli-nix/commit/84ef41fa58a1731da7e2d9856f8358cdbec8f6e3) ([compare](https://github.com/sadjow/codex-cli-nix/compare/828b885b1be90991a2bd1087f2afd722476bfaed...84ef41fa58a1731da7e2d9856f8358cdbec8f6e3))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`b931102`](https://github.com/nix-community/home-manager/commit/b9311028044a9e9b2cf27db15ef0a87d464e212d) -> [`e4419d3`](https://github.com/nix-community/home-manager/commit/e4419d3123b780d5f4c0bceeace450424387638c) ([compare](https://github.com/nix-community/home-manager/compare/b9311028044a9e9b2cf27db15ef0a87d464e212d...e4419d3123b780d5f4c0bceeace450424387638c))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`90a39a3`](https://github.com/ryoppippi/nix-claude-code/commit/90a39a32b51501c1ae3af6918c1bcea2415ce345) -> [`ffd7ac5`](https://github.com/ryoppippi/nix-claude-code/commit/ffd7ac55d04a57083aa421d6598235127a7faf38) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/90a39a32b51501c1ae3af6918c1bcea2415ce345...ffd7ac55d04a57083aa421d6598235127a7faf38))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`b8eb7ac`](https://github.com/Mic92/nix-index-database/commit/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa) -> [`2dea2b9`](https://github.com/Mic92/nix-index-database/commit/2dea2b920e7127b3afa8506713f23536651de312) ([compare](https://github.com/Mic92/nix-index-database/compare/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa...2dea2b920e7127b3afa8506713f23536651de312))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`2096f3f`](https://github.com/nixos/nixos-hardware/commit/2096f3f411ce46e88a79ae4eafcfc9df8ed41c61) -> [`3bcaa36`](https://github.com/nixos/nixos-hardware/commit/3bcaa367d4c550d687a17ac792fd5cda214ee871) ([compare](https://github.com/nixos/nixos-hardware/compare/2096f3f411ce46e88a79ae4eafcfc9df8ed41c61...3bcaa367d4c550d687a17ac792fd5cda214ee871))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`15f4ee4`](https://github.com/nixos/nixpkgs/commit/15f4ee454b1dce334612fa6843b3e05cf546efab) -> [`549bd84`](https://github.com/nixos/nixpkgs/commit/549bd84d6279f9852cae6225e372cc67fb91a4c1) ([compare](https://github.com/nixos/nixpkgs/compare/15f4ee454b1dce334612fa6843b3e05cf546efab...549bd84d6279f9852cae6225e372cc67fb91a4c1))
- `sbomnix`: [`tiiuae/sbomnix`](https://github.com/tiiuae/sbomnix) [`f684e6b`](https://github.com/tiiuae/sbomnix/commit/f684e6b971b086e2510025d6fbb75dc068d00a57) -> [`6fb9c67`](https://github.com/tiiuae/sbomnix/commit/6fb9c6707ff33f904213550ec18aac1d346d36af) ([compare](https://github.com/tiiuae/sbomnix/compare/f684e6b971b086e2510025d6fbb75dc068d00a57...6fb9c6707ff33f904213550ec18aac1d346d36af))
- `sops-nix`: [`Mic92/sops-nix`](https://github.com/Mic92/sops-nix) [`8eaee5c`](https://github.com/Mic92/sops-nix/commit/8eaee5c45428b28b8c47a83e4c09dccec5f279b5) -> [`c591bf6`](https://github.com/Mic92/sops-nix/commit/c591bf665727040c6cc5cb409079acb22dcce33c) ([compare](https://github.com/Mic92/sops-nix/compare/8eaee5c45428b28b8c47a83e4c09dccec5f279b5...c591bf665727040c6cc5cb409079acb22dcce33c))
