### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778282716,
-        "narHash": "sha256-fHo9PlYWu970hmdVkDB2Jqeu0VmhmqQ5iKOnPjf/I1E=",
+        "lastModified": 1779246963,
+        "narHash": "sha256-6mEF9tTbrvCN9DLWVPKm79yrGwo00dn4Ia3y6pz05Sc=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "7f0f3802287581e04501e2fea26b56d63df18ebd",
+        "rev": "b1b44fd7da742655b37e949d3cb4fe329067e271",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778628724,
-        "narHash": "sha256-VNG6hJ146VEenXcDrB3t6MVnrMx+gtyCWTCDkzOp9Qs=",
+        "lastModified": 1779336838,
+        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a0bbd6b4720da1c9ce7ebf35ff5c41a82db367a",
+        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778617782,
-        "narHash": "sha256-aVtG1o+OZEYD7XdIygmWtmGiBP1gpQgHIYYhb7PgAjc=",
+        "lastModified": 1779309515,
+        "narHash": "sha256-ahjFWfBv0cC52SPgLNF06dVHYlOzCLSllecFK/K2MPw=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "aa569233a9ed71a4e3f6927383a9200bda85f2fa",
+        "rev": "65cec3b679cf8935074c7574d813c3d567ca954a",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778393439,
-        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
+        "lastModified": 1778999127,
+        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
+        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1778593042,
-        "narHash": "sha256-xYGrSg6354UK2K4WSQd4+TfyvfqmvFbSY+ZtGQUXK0c=",
+        "lastModified": 1779258371,
+        "narHash": "sha256-j1iZsLy6oFApqR1oiDmHhvkwxXqcNi0aoSJj643LuwU=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "9bd7c80d43e258aaa607d83b43661df11444d808",
+        "rev": "c97bc4d15bd3473dd095e8e8ba57330ab1943a77",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -322,14 +322,15 @@
         "git-hooks-nix": "git-hooks-nix_2",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "vulnix": "vulnix"
       },
       "locked": {
-        "lastModified": 1778586023,
-        "narHash": "sha256-2qdaERrQrF3yatY3GlYc5YbWae4wvm4toLS8Y/oKGJ8=",
+        "lastModified": 1778658483,
+        "narHash": "sha256-FZzQQ8tc/LKNbSXLlfc/z/JwYqE6Di9R/YoRnm9zFWM=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "a13ee11f1e3bd9aec66ae9ea1ec5b90b157c298a",
+        "rev": "ef52049e0c9a62ff8acc9379fcb14292ee7fdd8d",
         "type": "github"
       },
       "original": {
@@ -370,6 +371,63 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "sbomnix",
+          "vulnix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "vulnix": {
+      "inputs": {
+        "flake-compat": [
+          "sbomnix",
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "sbomnix",
+          "flake-parts"
+        ],
+        "flake-root": [
+          "sbomnix",
+          "flake-root"
+        ],
+        "nixpkgs": [
+          "sbomnix",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1778651554,
+        "narHash": "sha256-QxkkaBVdIIot/YVxPuzUhjP7cDAp7U9iJXWozVTcuww=",
+        "owner": "nix-community",
+        "repo": "vulnix",
+        "rev": "038b06e335c41d7d2dcbccbf4f821f95d7c17b16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "vulnix",
         "type": "github"
       }
     }


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`7f0f380`](https://github.com/sadjow/codex-cli-nix/commit/7f0f3802287581e04501e2fea26b56d63df18ebd) -> [`b1b44fd`](https://github.com/sadjow/codex-cli-nix/commit/b1b44fd7da742655b37e949d3cb4fe329067e271) ([compare](https://github.com/sadjow/codex-cli-nix/compare/7f0f3802287581e04501e2fea26b56d63df18ebd...b1b44fd7da742655b37e949d3cb4fe329067e271))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`6a0bbd6`](https://github.com/nix-community/home-manager/commit/6a0bbd6b4720da1c9ce7ebf35ff5c41a82db367a) -> [`928d723`](https://github.com/nix-community/home-manager/commit/928d72376949e222ea4f07b44828a55b0136422e) ([compare](https://github.com/nix-community/home-manager/compare/6a0bbd6b4720da1c9ce7ebf35ff5c41a82db367a...928d72376949e222ea4f07b44828a55b0136422e))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`aa56923`](https://github.com/ryoppippi/nix-claude-code/commit/aa569233a9ed71a4e3f6927383a9200bda85f2fa) -> [`65cec3b`](https://github.com/ryoppippi/nix-claude-code/commit/65cec3b679cf8935074c7574d813c3d567ca954a) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/aa569233a9ed71a4e3f6927383a9200bda85f2fa...65cec3b679cf8935074c7574d813c3d567ca954a))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`01466c4`](https://github.com/Mic92/nix-index-database/commit/01466c414c7357ae2ce32be4a272a7c69e94ab5f) -> [`f680e0d`](https://github.com/Mic92/nix-index-database/commit/f680e0d3c1dbefe298c423691662e238496890f2) ([compare](https://github.com/Mic92/nix-index-database/compare/01466c414c7357ae2ce32be4a272a7c69e94ab5f...f680e0d3c1dbefe298c423691662e238496890f2))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`9bd7c80`](https://github.com/nixos/nixos-hardware/commit/9bd7c80d43e258aaa607d83b43661df11444d808) -> [`c97bc4d`](https://github.com/nixos/nixos-hardware/commit/c97bc4d15bd3473dd095e8e8ba57330ab1943a77) ([compare](https://github.com/nixos/nixos-hardware/compare/9bd7c80d43e258aaa607d83b43661df11444d808...c97bc4d15bd3473dd095e8e8ba57330ab1943a77))
- `nixpkgs`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`da5ad66`](https://github.com/nixos/nixpkgs/commit/da5ad661ba4e5ef59ba743f0d112cbc30e474f32) -> [`d233902`](https://github.com/nixos/nixpkgs/commit/d233902339c02a9c334e7e593de68855ad26c4cb) ([compare](https://github.com/nixos/nixpkgs/compare/da5ad661ba4e5ef59ba743f0d112cbc30e474f32...d233902339c02a9c334e7e593de68855ad26c4cb))
- `sbomnix`: [`tiiuae/sbomnix`](https://github.com/tiiuae/sbomnix) [`a13ee11`](https://github.com/tiiuae/sbomnix/commit/a13ee11f1e3bd9aec66ae9ea1ec5b90b157c298a) -> [`ef52049`](https://github.com/tiiuae/sbomnix/commit/ef52049e0c9a62ff8acc9379fcb14292ee7fdd8d) ([compare](https://github.com/tiiuae/sbomnix/compare/a13ee11f1e3bd9aec66ae9ea1ec5b90b157c298a...ef52049e0c9a62ff8acc9379fcb14292ee7fdd8d))
