### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779998039,
-        "narHash": "sha256-TrNmfalbdX4VOXJyBYDX+jH6Ph7YJbUMAnq6/akCyms=",
+        "lastModified": 1780345858,
+        "narHash": "sha256-t3dxFjzEFbuMd7o8LWtbnqfOkXDKjzvHXUiXQwvwXtk=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "803b7de2cccae3abbb9d23c10826af087428b06e",
+        "rev": "ea8119de14a2263330da99363e6303db10a0f84b",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779969295,
-        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
+        "lastModified": 1780370888,
+        "narHash": "sha256-PRJj9RKTEf/sITycujP1c/BrvLJKMYXzcpwTsXNulXQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
+        "rev": "a7a415883195ffbd4dabec8f098f201e6eaaadf8",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780030383,
-        "narHash": "sha256-vininGIqTM3wYHDejG3c/cfHgVQch4T8e2heXHP5emA=",
+        "lastModified": 1780348180,
+        "narHash": "sha256-52IbBND56yikEf8FEwfmsVCfQNc6FMBST+++SooODfc=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "02fce910bfd96f2dc9e2df734bd53fbe198b2eb0",
+        "rev": "cd47177fa859bc3c1cc994a502a691a8dd0f2d35",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779604987,
-        "narHash": "sha256-ZQ5z+fVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs+s=",
+        "lastModified": 1780210899,
+        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "8fba98c80b48fa013820e0163c5096922fea4ddd",
+        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780065812,
-        "narHash": "sha256-SCSLUKBmwlSLGQ8Xbr8PjRFtiHNk0l9ktqkcmqdBkfE=",
+        "lastModified": 1780310866,
+        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "b76b5639c0593e0aeb0b5879ad62d4b30596c144",
+        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
         "type": "github"
       },
       "original": {
@@ -303,11 +303,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -342,11 +342,11 @@
         "vulnix": "vulnix"
       },
       "locked": {
-        "lastModified": 1779684811,
-        "narHash": "sha256-MwIB6wgkKTdifTfokxf8N1z044r99iDA/wxqMQC8jLo=",
+        "lastModified": 1780374210,
+        "narHash": "sha256-8ZYGP9OpNtcZ5JBZw8Mkw+WpUFI8HVK8vSibnTDdaHw=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "8e94a4a7f0983215141e0a50b45977353b56ba94",
+        "rev": "ee8f0031cf0dd477477e45a114f0796425444635",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`803b7de`](https://github.com/sadjow/codex-cli-nix/commit/803b7de2cccae3abbb9d23c10826af087428b06e) -> [`ea8119d`](https://github.com/sadjow/codex-cli-nix/commit/ea8119de14a2263330da99363e6303db10a0f84b) ([compare](https://github.com/sadjow/codex-cli-nix/compare/803b7de2cccae3abbb9d23c10826af087428b06e...ea8119de14a2263330da99363e6303db10a0f84b))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`61e2c96`](https://github.com/nix-community/home-manager/commit/61e2c9659324181e0f0ed911958c536333b1d4f6) -> [`a7a4158`](https://github.com/nix-community/home-manager/commit/a7a415883195ffbd4dabec8f098f201e6eaaadf8) ([compare](https://github.com/nix-community/home-manager/compare/61e2c9659324181e0f0ed911958c536333b1d4f6...a7a415883195ffbd4dabec8f098f201e6eaaadf8))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`02fce91`](https://github.com/ryoppippi/nix-claude-code/commit/02fce910bfd96f2dc9e2df734bd53fbe198b2eb0) -> [`cd47177`](https://github.com/ryoppippi/nix-claude-code/commit/cd47177fa859bc3c1cc994a502a691a8dd0f2d35) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/02fce910bfd96f2dc9e2df734bd53fbe198b2eb0...cd47177fa859bc3c1cc994a502a691a8dd0f2d35))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`8fba98c`](https://github.com/Mic92/nix-index-database/commit/8fba98c80b48fa013820e0163c5096922fea4ddd) -> [`97df9dc`](https://github.com/Mic92/nix-index-database/commit/97df9dc0b7c924344b793a15c1e8e4522ebb854e) ([compare](https://github.com/Mic92/nix-index-database/compare/8fba98c80b48fa013820e0163c5096922fea4ddd...97df9dc0b7c924344b793a15c1e8e4522ebb854e))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`b76b563`](https://github.com/nixos/nixos-hardware/commit/b76b5639c0593e0aeb0b5879ad62d4b30596c144) -> [`4ed851c`](https://github.com/nixos/nixos-hardware/commit/4ed851c979641e28597a05086332d75cdc9e395f) ([compare](https://github.com/nixos/nixos-hardware/compare/b76b5639c0593e0aeb0b5879ad62d4b30596c144...4ed851c979641e28597a05086332d75cdc9e395f))
- `nixpkgs_2`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`64c08a7`](https://github.com/nixos/nixpkgs/commit/64c08a7ca051951c8eae34e3e3cb1e202fe36786) -> [`331800d`](https://github.com/nixos/nixpkgs/commit/331800de5053fcebacf6813adb5db9c9dca22a0c) ([compare](https://github.com/nixos/nixpkgs/compare/64c08a7ca051951c8eae34e3e3cb1e202fe36786...331800de5053fcebacf6813adb5db9c9dca22a0c))
- `sbomnix`: [`tiiuae/sbomnix`](https://github.com/tiiuae/sbomnix) [`8e94a4a`](https://github.com/tiiuae/sbomnix/commit/8e94a4a7f0983215141e0a50b45977353b56ba94) -> [`ee8f003`](https://github.com/tiiuae/sbomnix/commit/ee8f0031cf0dd477477e45a114f0796425444635) ([compare](https://github.com/tiiuae/sbomnix/compare/8e94a4a7f0983215141e0a50b45977353b56ba94...ee8f0031cf0dd477477e45a114f0796425444635))
