### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780345858,
-        "narHash": "sha256-t3dxFjzEFbuMd7o8LWtbnqfOkXDKjzvHXUiXQwvwXtk=",
+        "lastModified": 1780543091,
+        "narHash": "sha256-qdsCTv+i0YHjFY/DUb2paaxUzUUFrO+BZzKhPKc1m2Q=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "ea8119de14a2263330da99363e6303db10a0f84b",
+        "rev": "d95f4900331633d49b8df26cfb4142742baa537b",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780408569,
-        "narHash": "sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg=",
+        "lastModified": 1780515920,
+        "narHash": "sha256-8KX2hEeOX6KP3hBBJJI8dGWVrzbOOf1rBPmg/GUG24U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f384af1bec6423a0d4ba1855917ab948f64e5808",
+        "rev": "4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780424083,
-        "narHash": "sha256-rLZlfCYiYsHZVaJSB9/gptH2wVrlCRoNh8NBWi4flnU=",
+        "lastModified": 1780524107,
+        "narHash": "sha256-ZW7xOkYJ1T3aSvexWLbVzFiqAZjaCg0pLVNO0A2jvwA=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "0c2e95452c12f9df8e7f1978e8a348c71b22758c",
+        "rev": "9ea1ec8f5a40317893ad79e278602f607f214e9c",
         "type": "github"
       },
       "original": {
@@ -362,11 +362,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`ea8119d`](https://github.com/sadjow/codex-cli-nix/commit/ea8119de14a2263330da99363e6303db10a0f84b) -> [`d95f490`](https://github.com/sadjow/codex-cli-nix/commit/d95f4900331633d49b8df26cfb4142742baa537b) ([compare](https://github.com/sadjow/codex-cli-nix/compare/ea8119de14a2263330da99363e6303db10a0f84b...d95f4900331633d49b8df26cfb4142742baa537b))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`f384af1`](https://github.com/nix-community/home-manager/commit/f384af1bec6423a0d4ba1855917ab948f64e5808) -> [`4c5c1e8`](https://github.com/nix-community/home-manager/commit/4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974) ([compare](https://github.com/nix-community/home-manager/compare/f384af1bec6423a0d4ba1855917ab948f64e5808...4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`0c2e954`](https://github.com/ryoppippi/nix-claude-code/commit/0c2e95452c12f9df8e7f1978e8a348c71b22758c) -> [`9ea1ec8`](https://github.com/ryoppippi/nix-claude-code/commit/9ea1ec8f5a40317893ad79e278602f607f214e9c) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/0c2e95452c12f9df8e7f1978e8a348c71b22758c...9ea1ec8f5a40317893ad79e278602f607f214e9c))
- `sops-nix`: [`Mic92/sops-nix`](https://github.com/Mic92/sops-nix) [`c591bf6`](https://github.com/Mic92/sops-nix/commit/c591bf665727040c6cc5cb409079acb22dcce33c) -> [`9ed6585`](https://github.com/Mic92/sops-nix/commit/9ed65852b6257fbeae4355bc24ecfea307ca759a) ([compare](https://github.com/Mic92/sops-nix/compare/c591bf665727040c6cc5cb409079acb22dcce33c...9ed65852b6257fbeae4355bc24ecfea307ca759a))
