### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780515920,
-        "narHash": "sha256-8KX2hEeOX6KP3hBBJJI8dGWVrzbOOf1rBPmg/GUG24U=",
+        "lastModified": 1780885330,
+        "narHash": "sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974",
+        "rev": "4fe95527cbe952713318ada8a4d122e1a6ab120f",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780524107,
-        "narHash": "sha256-ZW7xOkYJ1T3aSvexWLbVzFiqAZjaCg0pLVNO0A2jvwA=",
+        "lastModified": 1780791733,
+        "narHash": "sha256-2sVYZ9cIVhR9LCcJUJelsufF/QYVooInli+5b1RCvaQ=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "9ea1ec8f5a40317893ad79e278602f607f214e9c",
+        "rev": "6ce2c98b036d3d977d6c44ffa201ed560efc53a9",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780210899,
-        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
+        "lastModified": 1780816331,
+        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
+        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
         "type": "github"
       },
       "original": {
@@ -303,11 +303,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`4c5c1e8`](https://github.com/nix-community/home-manager/commit/4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974) -> [`4fe9552`](https://github.com/nix-community/home-manager/commit/4fe95527cbe952713318ada8a4d122e1a6ab120f) ([compare](https://github.com/nix-community/home-manager/compare/4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974...4fe95527cbe952713318ada8a4d122e1a6ab120f))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`9ea1ec8`](https://github.com/ryoppippi/nix-claude-code/commit/9ea1ec8f5a40317893ad79e278602f607f214e9c) -> [`6ce2c98`](https://github.com/ryoppippi/nix-claude-code/commit/6ce2c98b036d3d977d6c44ffa201ed560efc53a9) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/9ea1ec8f5a40317893ad79e278602f607f214e9c...6ce2c98b036d3d977d6c44ffa201ed560efc53a9))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`97df9dc`](https://github.com/Mic92/nix-index-database/commit/97df9dc0b7c924344b793a15c1e8e4522ebb854e) -> [`1a2ea89`](https://github.com/Mic92/nix-index-database/commit/1a2ea89c917781e88508d9fd2b507f2d2a0e173c) ([compare](https://github.com/Mic92/nix-index-database/compare/97df9dc0b7c924344b793a15c1e8e4522ebb854e...1a2ea89c917781e88508d9fd2b507f2d2a0e173c))
- `nixpkgs_2`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`331800d`](https://github.com/nixos/nixpkgs/commit/331800de5053fcebacf6813adb5db9c9dca22a0c) -> [`a799d3e`](https://github.com/nixos/nixpkgs/commit/a799d3e3886da994fa307f817a6bc705ae538eeb) ([compare](https://github.com/nixos/nixpkgs/compare/331800de5053fcebacf6813adb5db9c9dca22a0c...a799d3e3886da994fa307f817a6bc705ae538eeb))
