### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780543091,
-        "narHash": "sha256-qdsCTv+i0YHjFY/DUb2paaxUzUUFrO+BZzKhPKc1m2Q=",
+        "lastModified": 1781038009,
+        "narHash": "sha256-MxvxXJ+EJxB9On3VfwjHLfeZFSB8Xlqz1IRpl43F76Q=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "d95f4900331633d49b8df26cfb4142742baa537b",
+        "rev": "75d6b831e036029e3d5f60b4f128dc0121730c37",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780885330,
-        "narHash": "sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs=",
+        "lastModified": 1781043330,
+        "narHash": "sha256-eApJsGv0lSn8OKqcBQJDFZI6Jg8coS7M8urNo3cVl9U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4fe95527cbe952713318ada8a4d122e1a6ab120f",
+        "rev": "bd4277722d215970366a405d280301a796a364fc",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780791733,
-        "narHash": "sha256-2sVYZ9cIVhR9LCcJUJelsufF/QYVooInli+5b1RCvaQ=",
+        "lastModified": 1781026631,
+        "narHash": "sha256-qyce0vA13NM6TL7Nm3binmGCx/AQw2Ms7ZnXf/hFkww=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "6ce2c98b036d3d977d6c44ffa201ed560efc53a9",
+        "rev": "6b680cfac93a57860ee25e5ea5a70e58c6bb6724",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780310866,
-        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
+        "lastModified": 1781020964,
+        "narHash": "sha256-fS7xTi2j2iso5Hj7RNZLv/acDlCT+fgMVkVk40A7Uco=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
+        "rev": "32c2cd9e46286c4eced3dc6b613c659126bf3cca",
         "type": "github"
       },
       "original": {
@@ -342,11 +342,11 @@
         "vulnix": "vulnix"
       },
       "locked": {
-        "lastModified": 1780374210,
-        "narHash": "sha256-8ZYGP9OpNtcZ5JBZw8Mkw+WpUFI8HVK8vSibnTDdaHw=",
+        "lastModified": 1780995381,
+        "narHash": "sha256-q91Amk0tTbACseVLmvd3LhBixcACyskVHD7lo1mSf28=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "ee8f0031cf0dd477477e45a114f0796425444635",
+        "rev": "30c95eb2fc0c402300ee05354c5cf84c7e5f74e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`d95f490`](https://github.com/sadjow/codex-cli-nix/commit/d95f4900331633d49b8df26cfb4142742baa537b) -> [`75d6b83`](https://github.com/sadjow/codex-cli-nix/commit/75d6b831e036029e3d5f60b4f128dc0121730c37) ([compare](https://github.com/sadjow/codex-cli-nix/compare/d95f4900331633d49b8df26cfb4142742baa537b...75d6b831e036029e3d5f60b4f128dc0121730c37))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`4fe9552`](https://github.com/nix-community/home-manager/commit/4fe95527cbe952713318ada8a4d122e1a6ab120f) -> [`bd42777`](https://github.com/nix-community/home-manager/commit/bd4277722d215970366a405d280301a796a364fc) ([compare](https://github.com/nix-community/home-manager/compare/4fe95527cbe952713318ada8a4d122e1a6ab120f...bd4277722d215970366a405d280301a796a364fc))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`6ce2c98`](https://github.com/ryoppippi/nix-claude-code/commit/6ce2c98b036d3d977d6c44ffa201ed560efc53a9) -> [`6b680cf`](https://github.com/ryoppippi/nix-claude-code/commit/6b680cfac93a57860ee25e5ea5a70e58c6bb6724) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/6ce2c98b036d3d977d6c44ffa201ed560efc53a9...6b680cfac93a57860ee25e5ea5a70e58c6bb6724))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`4ed851c`](https://github.com/nixos/nixos-hardware/commit/4ed851c979641e28597a05086332d75cdc9e395f) -> [`32c2cd9`](https://github.com/nixos/nixos-hardware/commit/32c2cd9e46286c4eced3dc6b613c659126bf3cca) ([compare](https://github.com/nixos/nixos-hardware/compare/4ed851c979641e28597a05086332d75cdc9e395f...32c2cd9e46286c4eced3dc6b613c659126bf3cca))
- `sbomnix`: [`tiiuae/sbomnix`](https://github.com/tiiuae/sbomnix) [`ee8f003`](https://github.com/tiiuae/sbomnix/commit/ee8f0031cf0dd477477e45a114f0796425444635) -> [`30c95eb`](https://github.com/tiiuae/sbomnix/commit/30c95eb2fc0c402300ee05354c5cf84c7e5f74e2) ([compare](https://github.com/tiiuae/sbomnix/compare/ee8f0031cf0dd477477e45a114f0796425444635...30c95eb2fc0c402300ee05354c5cf84c7e5f74e2))
