### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781043330,
-        "narHash": "sha256-eApJsGv0lSn8OKqcBQJDFZI6Jg8coS7M8urNo3cVl9U=",
+        "lastModified": 1781189114,
+        "narHash": "sha256-5inaamLgUMWy+MOBE9ChF9QAF1o/74LFuHkI0W/9rqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd4277722d215970366a405d280301a796a364fc",
+        "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781026631,
-        "narHash": "sha256-qyce0vA13NM6TL7Nm3binmGCx/AQw2Ms7ZnXf/hFkww=",
+        "lastModified": 1781217107,
+        "narHash": "sha256-dAsZf9u3oQb3LQ40qpbqubcBd6lZtXrM66akiNwTiOQ=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "6b680cfac93a57860ee25e5ea5a70e58c6bb6724",
+        "rev": "9af8f2c35681e5dc4f449fd79051f54f19b6636d",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781020964,
-        "narHash": "sha256-fS7xTi2j2iso5Hj7RNZLv/acDlCT+fgMVkVk40A7Uco=",
+        "lastModified": 1781168557,
+        "narHash": "sha256-LOnLQ2tpYF9gqIDDr3+j3DbpJJr/QCH6zPRT2GzEUOE=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "32c2cd9e46286c4eced3dc6b613c659126bf3cca",
+        "rev": "6358ff76821101c178e3ab4919a62799bfe3652e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`bd42777`](https://github.com/nix-community/home-manager/commit/bd4277722d215970366a405d280301a796a364fc) -> [`486595d`](https://github.com/nix-community/home-manager/commit/486595d2cf49cfcd649b58a284fa11ac0e34da22) ([compare](https://github.com/nix-community/home-manager/compare/bd4277722d215970366a405d280301a796a364fc...486595d2cf49cfcd649b58a284fa11ac0e34da22))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`6b680cf`](https://github.com/ryoppippi/nix-claude-code/commit/6b680cfac93a57860ee25e5ea5a70e58c6bb6724) -> [`9af8f2c`](https://github.com/ryoppippi/nix-claude-code/commit/9af8f2c35681e5dc4f449fd79051f54f19b6636d) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/6b680cfac93a57860ee25e5ea5a70e58c6bb6724...9af8f2c35681e5dc4f449fd79051f54f19b6636d))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`32c2cd9`](https://github.com/nixos/nixos-hardware/commit/32c2cd9e46286c4eced3dc6b613c659126bf3cca) -> [`6358ff7`](https://github.com/nixos/nixos-hardware/commit/6358ff76821101c178e3ab4919a62799bfe3652e) ([compare](https://github.com/nixos/nixos-hardware/compare/32c2cd9e46286c4eced3dc6b613c659126bf3cca...6358ff76821101c178e3ab4919a62799bfe3652e))
