### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781038009,
-        "narHash": "sha256-MxvxXJ+EJxB9On3VfwjHLfeZFSB8Xlqz1IRpl43F76Q=",
+        "lastModified": 1781560525,
+        "narHash": "sha256-3uXRmKF+CYUfkhOucmJP5d8Z1Q4TNy0xH0jE1x9R3ZY=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "75d6b831e036029e3d5f60b4f128dc0121730c37",
+        "rev": "00f0c98099998b0044bf3aa144c931bb33671669",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781365335,
-        "narHash": "sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/+4ieMHDC+ZXo=",
+        "lastModified": 1781642113,
+        "narHash": "sha256-mAR7KTS9rjreTcXCNqfCbN96mnhJO8lDQq1vl7GviBQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c",
+        "rev": "df4e0465717a2d34f05b8ccd967275aaf3ceaa01",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781314789,
-        "narHash": "sha256-8NKDVtaeAMga6p6zt5X83FF7sTHhuMSOUvFPqHnUkfg=",
+        "lastModified": 1781643499,
+        "narHash": "sha256-LvZ0z+/Gel2gagHmjQl+C58BzQubVx9nqJv+k8DqAz8=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "b5ed5120201378e4007ac024de1c74a8f69216e1",
+        "rev": "80dd4053d9a494c0d7a8c4baccdfa38451bdc78e",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780816331,
-        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
+        "lastModified": 1781422160,
+        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
+        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781168557,
-        "narHash": "sha256-LOnLQ2tpYF9gqIDDr3+j3DbpJJr/QCH6zPRT2GzEUOE=",
+        "lastModified": 1781622756,
+        "narHash": "sha256-JrPh4M6S7aPsEE9tOENuZrxC6o2szSLlK+t4+nLke9s=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "6358ff76821101c178e3ab4919a62799bfe3652e",
+        "rev": "08018c72174a4df5657f8d94178ac69fb9c243e5",
         "type": "github"
       },
       "original": {
@@ -303,11 +303,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`75d6b83`](https://github.com/sadjow/codex-cli-nix/commit/75d6b831e036029e3d5f60b4f128dc0121730c37) -> [`00f0c98`](https://github.com/sadjow/codex-cli-nix/commit/00f0c98099998b0044bf3aa144c931bb33671669) ([compare](https://github.com/sadjow/codex-cli-nix/compare/75d6b831e036029e3d5f60b4f128dc0121730c37...00f0c98099998b0044bf3aa144c931bb33671669))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`5b6f573`](https://github.com/nix-community/home-manager/commit/5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c) -> [`df4e046`](https://github.com/nix-community/home-manager/commit/df4e0465717a2d34f05b8ccd967275aaf3ceaa01) ([compare](https://github.com/nix-community/home-manager/compare/5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c...df4e0465717a2d34f05b8ccd967275aaf3ceaa01))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`b5ed512`](https://github.com/ryoppippi/nix-claude-code/commit/b5ed5120201378e4007ac024de1c74a8f69216e1) -> [`80dd405`](https://github.com/ryoppippi/nix-claude-code/commit/80dd4053d9a494c0d7a8c4baccdfa38451bdc78e) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/b5ed5120201378e4007ac024de1c74a8f69216e1...80dd4053d9a494c0d7a8c4baccdfa38451bdc78e))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`1a2ea89`](https://github.com/Mic92/nix-index-database/commit/1a2ea89c917781e88508d9fd2b507f2d2a0e173c) -> [`854d04e`](https://github.com/Mic92/nix-index-database/commit/854d04e2368fb2e9c328a36b3c0a04cd713bfae1) ([compare](https://github.com/Mic92/nix-index-database/compare/1a2ea89c917781e88508d9fd2b507f2d2a0e173c...854d04e2368fb2e9c328a36b3c0a04cd713bfae1))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`6358ff7`](https://github.com/nixos/nixos-hardware/commit/6358ff76821101c178e3ab4919a62799bfe3652e) -> [`08018c7`](https://github.com/nixos/nixos-hardware/commit/08018c72174a4df5657f8d94178ac69fb9c243e5) ([compare](https://github.com/nixos/nixos-hardware/compare/6358ff76821101c178e3ab4919a62799bfe3652e...08018c72174a4df5657f8d94178ac69fb9c243e5))
- `nixpkgs_2`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`9ae611a`](https://github.com/nixos/nixpkgs/commit/9ae611a455b90cf061d8f332b977e387bda8e1ca) -> [`567a49d`](https://github.com/nixos/nixpkgs/commit/567a49d1913ce81ac6e9582e3553dd90a955875f) ([compare](https://github.com/nixos/nixpkgs/compare/9ae611a455b90cf061d8f332b977e387bda8e1ca...567a49d1913ce81ac6e9582e3553dd90a955875f))
