### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781642113,
-        "narHash": "sha256-mAR7KTS9rjreTcXCNqfCbN96mnhJO8lDQq1vl7GviBQ=",
+        "lastModified": 1781729244,
+        "narHash": "sha256-vT1hM3l+vH1h9BHhuxkAsJmAPl6Rld7cjLVEGtHGzOA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "df4e0465717a2d34f05b8ccd967275aaf3ceaa01",
+        "rev": "c51ac59e59f2a7362d71d1d01ab68b2c09d09347",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781643499,
-        "narHash": "sha256-LvZ0z+/Gel2gagHmjQl+C58BzQubVx9nqJv+k8DqAz8=",
+        "lastModified": 1781735471,
+        "narHash": "sha256-kqudiKV9V9iKUJ9tpfdCfnQCuEmP/zsmJnHKujWUJhg=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "80dd4053d9a494c0d7a8c4baccdfa38451bdc78e",
+        "rev": "60d19570ba884031c1ff23c5048a1801cf362548",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `git-hooks-nix`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`61ab0e8`](https://github.com/cachix/git-hooks.nix/commit/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a) -> [`3bbec39`](https://github.com/cachix/git-hooks.nix/commit/3bbec39bc90eadfa031e6f3b77272f3f60803e39) ([compare](https://github.com/cachix/git-hooks.nix/compare/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a...3bbec39bc90eadfa031e6f3b77272f3f60803e39))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`df4e046`](https://github.com/nix-community/home-manager/commit/df4e0465717a2d34f05b8ccd967275aaf3ceaa01) -> [`c51ac59`](https://github.com/nix-community/home-manager/commit/c51ac59e59f2a7362d71d1d01ab68b2c09d09347) ([compare](https://github.com/nix-community/home-manager/compare/df4e0465717a2d34f05b8ccd967275aaf3ceaa01...c51ac59e59f2a7362d71d1d01ab68b2c09d09347))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`80dd405`](https://github.com/ryoppippi/nix-claude-code/commit/80dd4053d9a494c0d7a8c4baccdfa38451bdc78e) -> [`60d1957`](https://github.com/ryoppippi/nix-claude-code/commit/60d19570ba884031c1ff23c5048a1801cf362548) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/80dd4053d9a494c0d7a8c4baccdfa38451bdc78e...60d19570ba884031c1ff23c5048a1801cf362548))
