### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781560525,
-        "narHash": "sha256-3uXRmKF+CYUfkhOucmJP5d8Z1Q4TNy0xH0jE1x9R3ZY=",
+        "lastModified": 1781761441,
+        "narHash": "sha256-ZXJdWelt7SwbQTh18krnNgSS2SRveK4aoqO3xPdODD8=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "00f0c98099998b0044bf3aa144c931bb33671669",
+        "rev": "e3e7751853ece92c2a05ba4e8feee54afdb668c8",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781729244,
-        "narHash": "sha256-vT1hM3l+vH1h9BHhuxkAsJmAPl6Rld7cjLVEGtHGzOA=",
+        "lastModified": 1781989573,
+        "narHash": "sha256-npfH7Zv7t1akX/ArqCNro4zU4ViPlghLaPnbEfHbCxk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c51ac59e59f2a7362d71d1d01ab68b2c09d09347",
+        "rev": "78e7d8b13ecd7f5256a5c11ce216876164099d9f",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781735471,
-        "narHash": "sha256-kqudiKV9V9iKUJ9tpfdCfnQCuEmP/zsmJnHKujWUJhg=",
+        "lastModified": 1781990768,
+        "narHash": "sha256-ATqZcf12YK9MBA9YIjawTVNHOUgvdly1Nn/tEWXin+Q=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "60d19570ba884031c1ff23c5048a1801cf362548",
+        "rev": "5a9925bc5fc811316e3e70f5e9f2b035c1b37a7c",
         "type": "github"
       },
       "original": {
@@ -362,11 +362,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780547341,
-        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
+        "lastModified": 1781943681,
+        "narHash": "sha256-NFHmA7H47adqiyp+0iEOyZOQhmigDqA/NBAlf4imB6U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
+        "rev": "420f8d2e9882911f65cfac15cc706f639ba96cca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`00f0c98`](https://github.com/sadjow/codex-cli-nix/commit/00f0c98099998b0044bf3aa144c931bb33671669) -> [`e3e7751`](https://github.com/sadjow/codex-cli-nix/commit/e3e7751853ece92c2a05ba4e8feee54afdb668c8) ([compare](https://github.com/sadjow/codex-cli-nix/compare/00f0c98099998b0044bf3aa144c931bb33671669...e3e7751853ece92c2a05ba4e8feee54afdb668c8))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`c51ac59`](https://github.com/nix-community/home-manager/commit/c51ac59e59f2a7362d71d1d01ab68b2c09d09347) -> [`78e7d8b`](https://github.com/nix-community/home-manager/commit/78e7d8b13ecd7f5256a5c11ce216876164099d9f) ([compare](https://github.com/nix-community/home-manager/compare/c51ac59e59f2a7362d71d1d01ab68b2c09d09347...78e7d8b13ecd7f5256a5c11ce216876164099d9f))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`60d1957`](https://github.com/ryoppippi/nix-claude-code/commit/60d19570ba884031c1ff23c5048a1801cf362548) -> [`5a9925b`](https://github.com/ryoppippi/nix-claude-code/commit/5a9925bc5fc811316e3e70f5e9f2b035c1b37a7c) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/60d19570ba884031c1ff23c5048a1801cf362548...5a9925bc5fc811316e3e70f5e9f2b035c1b37a7c))
- `sops-nix`: [`Mic92/sops-nix`](https://github.com/Mic92/sops-nix) [`9ed6585`](https://github.com/Mic92/sops-nix/commit/9ed65852b6257fbeae4355bc24ecfea307ca759a) -> [`420f8d2`](https://github.com/Mic92/sops-nix/commit/420f8d2e9882911f65cfac15cc706f639ba96cca) ([compare](https://github.com/Mic92/sops-nix/compare/9ed65852b6257fbeae4355bc24ecfea307ca759a...420f8d2e9882911f65cfac15cc706f639ba96cca))
