### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761441,
-        "narHash": "sha256-ZXJdWelt7SwbQTh18krnNgSS2SRveK4aoqO3xPdODD8=",
+        "lastModified": 1782167912,
+        "narHash": "sha256-2K3QoP1Y1ZFcWeHX+zVII5W1khgPN55AcfcbB7PnkQI=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "e3e7751853ece92c2a05ba4e8feee54afdb668c8",
+        "rev": "780625c2f90c991def2132e0b734d8ebb7138ecc",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781989573,
-        "narHash": "sha256-npfH7Zv7t1akX/ArqCNro4zU4ViPlghLaPnbEfHbCxk=",
+        "lastModified": 1782166451,
+        "narHash": "sha256-SA7LyrayyZBvtzZnesnSLV7haciFuVLeZaX2hd5v4j4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "78e7d8b13ecd7f5256a5c11ce216876164099d9f",
+        "rev": "471a1d2f840eb7fcbdfd541d99c13a64096f46db",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781990768,
-        "narHash": "sha256-ATqZcf12YK9MBA9YIjawTVNHOUgvdly1Nn/tEWXin+Q=",
+        "lastModified": 1782162467,
+        "narHash": "sha256-t+93quoh6LStcf15Q7ws8bBL8sIBfk/VQ7KYKtbgxW0=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "5a9925bc5fc811316e3e70f5e9f2b035c1b37a7c",
+        "rev": "6c7a4dcf7add443819eac7118151d92df2dfc60a",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781422160,
-        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
+        "lastModified": 1782030356,
+        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
+        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781622756,
-        "narHash": "sha256-JrPh4M6S7aPsEE9tOENuZrxC6o2szSLlK+t4+nLke9s=",
+        "lastModified": 1782166108,
+        "narHash": "sha256-/EtnQBcKbsaCAGQ5VRcplrHRkR4ryqyLMpBfkVuG9Xw=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "08018c72174a4df5657f8d94178ac69fb9c243e5",
+        "rev": "875776f0252fcb8618bb948640a0d1f7a5b362be",
         "type": "github"
       },
       "original": {
@@ -362,11 +362,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781943681,
-        "narHash": "sha256-NFHmA7H47adqiyp+0iEOyZOQhmigDqA/NBAlf4imB6U=",
+        "lastModified": 1782165805,
+        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "420f8d2e9882911f65cfac15cc706f639ba96cca",
+        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`e3e7751`](https://github.com/sadjow/codex-cli-nix/commit/e3e7751853ece92c2a05ba4e8feee54afdb668c8) -> [`780625c`](https://github.com/sadjow/codex-cli-nix/commit/780625c2f90c991def2132e0b734d8ebb7138ecc) ([compare](https://github.com/sadjow/codex-cli-nix/compare/e3e7751853ece92c2a05ba4e8feee54afdb668c8...780625c2f90c991def2132e0b734d8ebb7138ecc))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`78e7d8b`](https://github.com/nix-community/home-manager/commit/78e7d8b13ecd7f5256a5c11ce216876164099d9f) -> [`471a1d2`](https://github.com/nix-community/home-manager/commit/471a1d2f840eb7fcbdfd541d99c13a64096f46db) ([compare](https://github.com/nix-community/home-manager/compare/78e7d8b13ecd7f5256a5c11ce216876164099d9f...471a1d2f840eb7fcbdfd541d99c13a64096f46db))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`5a9925b`](https://github.com/ryoppippi/nix-claude-code/commit/5a9925bc5fc811316e3e70f5e9f2b035c1b37a7c) -> [`6c7a4dc`](https://github.com/ryoppippi/nix-claude-code/commit/6c7a4dcf7add443819eac7118151d92df2dfc60a) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/5a9925bc5fc811316e3e70f5e9f2b035c1b37a7c...6c7a4dcf7add443819eac7118151d92df2dfc60a))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`854d04e`](https://github.com/Mic92/nix-index-database/commit/854d04e2368fb2e9c328a36b3c0a04cd713bfae1) -> [`3017088`](https://github.com/Mic92/nix-index-database/commit/3017088b49efd404f78e3b104f553b97e4af786b) ([compare](https://github.com/Mic92/nix-index-database/compare/854d04e2368fb2e9c328a36b3c0a04cd713bfae1...3017088b49efd404f78e3b104f553b97e4af786b))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`08018c7`](https://github.com/nixos/nixos-hardware/commit/08018c72174a4df5657f8d94178ac69fb9c243e5) -> [`875776f`](https://github.com/nixos/nixos-hardware/commit/875776f0252fcb8618bb948640a0d1f7a5b362be) ([compare](https://github.com/nixos/nixos-hardware/compare/08018c72174a4df5657f8d94178ac69fb9c243e5...875776f0252fcb8618bb948640a0d1f7a5b362be))
- `sops-nix`: [`Mic92/sops-nix`](https://github.com/Mic92/sops-nix) [`420f8d2`](https://github.com/Mic92/sops-nix/commit/420f8d2e9882911f65cfac15cc706f639ba96cca) -> [`56b2406`](https://github.com/Mic92/sops-nix/commit/56b24064fdcaedca53553b1a6d607fd23b613a24) ([compare](https://github.com/Mic92/sops-nix/compare/420f8d2e9882911f65cfac15cc706f639ba96cca...56b24064fdcaedca53553b1a6d607fd23b613a24))
