### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782166451,
-        "narHash": "sha256-SA7LyrayyZBvtzZnesnSLV7haciFuVLeZaX2hd5v4j4=",
+        "lastModified": 1782233665,
+        "narHash": "sha256-h/xOtrByoA/Ak1lWHn0O1lVZz4qWYbwOSLQ8YSwQO0I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "471a1d2f840eb7fcbdfd541d99c13a64096f46db",
+        "rev": "062581938b4a378a82dfbb294b494808157153a1",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782162467,
-        "narHash": "sha256-t+93quoh6LStcf15Q7ws8bBL8sIBfk/VQ7KYKtbgxW0=",
+        "lastModified": 1782250208,
+        "narHash": "sha256-xpP6taZlx1WexPgk8c43zIbgXEipdZQgMkhsfkDNT9w=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "6c7a4dcf7add443819eac7118151d92df2dfc60a",
+        "rev": "2d96dbad11188a1913c7566def5e897b45921abb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`471a1d2`](https://github.com/nix-community/home-manager/commit/471a1d2f840eb7fcbdfd541d99c13a64096f46db) -> [`0625819`](https://github.com/nix-community/home-manager/commit/062581938b4a378a82dfbb294b494808157153a1) ([compare](https://github.com/nix-community/home-manager/compare/471a1d2f840eb7fcbdfd541d99c13a64096f46db...062581938b4a378a82dfbb294b494808157153a1))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`6c7a4dc`](https://github.com/ryoppippi/nix-claude-code/commit/6c7a4dcf7add443819eac7118151d92df2dfc60a) -> [`2d96dba`](https://github.com/ryoppippi/nix-claude-code/commit/2d96dbad11188a1913c7566def5e897b45921abb) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/6c7a4dcf7add443819eac7118151d92df2dfc60a...2d96dbad11188a1913c7566def5e897b45921abb))
