### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782167912,
-        "narHash": "sha256-2K3QoP1Y1ZFcWeHX+zVII5W1khgPN55AcfcbB7PnkQI=",
+        "lastModified": 1782378836,
+        "narHash": "sha256-TaT6D1jJUUyu17MI/wix4jb5MDXiomAE8V3OdK+tAL8=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "780625c2f90c991def2132e0b734d8ebb7138ecc",
+        "rev": "4751eb49f905fc1760b9f6ee7120bf5c32f4eb56",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782233665,
-        "narHash": "sha256-h/xOtrByoA/Ak1lWHn0O1lVZz4qWYbwOSLQ8YSwQO0I=",
+        "lastModified": 1782423922,
+        "narHash": "sha256-qPNd6lUohHP5gcJhqQ7rLV87RwIx0xYR2A4Frb9Zjc4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "062581938b4a378a82dfbb294b494808157153a1",
+        "rev": "5d320ab301cfaaca7d32514f13815d19d109f5f4",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782250208,
-        "narHash": "sha256-xpP6taZlx1WexPgk8c43zIbgXEipdZQgMkhsfkDNT9w=",
+        "lastModified": 1782426447,
+        "narHash": "sha256-KIve1fItFy3lTn+w9MbAwXlJTTIjONaAX7uynhk3f1k=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "2d96dbad11188a1913c7566def5e897b45921abb",
+        "rev": "17848a5b5beb2b9b4256c5e9c2873a634f62fc08",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1782166108,
-        "narHash": "sha256-/EtnQBcKbsaCAGQ5VRcplrHRkR4ryqyLMpBfkVuG9Xw=",
+        "lastModified": 1782379505,
+        "narHash": "sha256-zPvPiU+a7pqtH47xrtZLNRABJKpOjfZQclDbcvNtH+I=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "875776f0252fcb8618bb948640a0d1f7a5b362be",
+        "rev": "603d3afd1b6145bd66e97ae38a34d91c95df70cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`780625c`](https://github.com/sadjow/codex-cli-nix/commit/780625c2f90c991def2132e0b734d8ebb7138ecc) -> [`4751eb4`](https://github.com/sadjow/codex-cli-nix/commit/4751eb49f905fc1760b9f6ee7120bf5c32f4eb56) ([compare](https://github.com/sadjow/codex-cli-nix/compare/780625c2f90c991def2132e0b734d8ebb7138ecc...4751eb49f905fc1760b9f6ee7120bf5c32f4eb56))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`0625819`](https://github.com/nix-community/home-manager/commit/062581938b4a378a82dfbb294b494808157153a1) -> [`5d320ab`](https://github.com/nix-community/home-manager/commit/5d320ab301cfaaca7d32514f13815d19d109f5f4) ([compare](https://github.com/nix-community/home-manager/compare/062581938b4a378a82dfbb294b494808157153a1...5d320ab301cfaaca7d32514f13815d19d109f5f4))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`2d96dba`](https://github.com/ryoppippi/nix-claude-code/commit/2d96dbad11188a1913c7566def5e897b45921abb) -> [`17848a5`](https://github.com/ryoppippi/nix-claude-code/commit/17848a5b5beb2b9b4256c5e9c2873a634f62fc08) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/2d96dbad11188a1913c7566def5e897b45921abb...17848a5b5beb2b9b4256c5e9c2873a634f62fc08))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`875776f`](https://github.com/nixos/nixos-hardware/commit/875776f0252fcb8618bb948640a0d1f7a5b362be) -> [`603d3af`](https://github.com/nixos/nixos-hardware/commit/603d3afd1b6145bd66e97ae38a34d91c95df70cf) ([compare](https://github.com/nixos/nixos-hardware/compare/875776f0252fcb8618bb948640a0d1f7a5b362be...603d3afd1b6145bd66e97ae38a34d91c95df70cf))
