### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782378836,
-        "narHash": "sha256-TaT6D1jJUUyu17MI/wix4jb5MDXiomAE8V3OdK+tAL8=",
+        "lastModified": 1782875821,
+        "narHash": "sha256-Xii/zDQ2VB+Hpf5JHxWbk2PI6LOlFeIiZFGkTWqOQ+0=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "4751eb49f905fc1760b9f6ee7120bf5c32f4eb56",
+        "rev": "848bccf577af78fed932a7a16813e0628952405d",
         "type": "github"
       },
       "original": {
@@ -107,17 +107,16 @@
     "git-hooks-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
@@ -132,7 +131,7 @@
           "sbomnix",
           "flake-compat"
         ],
-        "gitignore": "gitignore_2",
+        "gitignore": "gitignore",
         "nixpkgs": [
           "sbomnix",
           "nixpkgs"
@@ -153,27 +152,6 @@
       }
     },
     "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
       "inputs": {
         "nixpkgs": [
           "sbomnix",
@@ -202,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782423922,
-        "narHash": "sha256-qPNd6lUohHP5gcJhqQ7rLV87RwIx0xYR2A4Frb9Zjc4=",
+        "lastModified": 1783222121,
+        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d320ab301cfaaca7d32514f13815d19d109f5f4",
+        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
         "type": "github"
       },
       "original": {
@@ -222,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782426447,
-        "narHash": "sha256-KIve1fItFy3lTn+w9MbAwXlJTTIjONaAX7uynhk3f1k=",
+        "lastModified": 1783113769,
+        "narHash": "sha256-NL+0uUZbJfre/K7+8HuM+2qgRJHPOcmIY2mCGKKavn8=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "17848a5b5beb2b9b4256c5e9c2873a634f62fc08",
+        "rev": "461ae41f8cf53e021400e122b3a3fa559cf987f1",
         "type": "github"
       },
       "original": {
@@ -242,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782030356,
-        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
+        "lastModified": 1783233851,
+        "narHash": "sha256-jzisD+3wWZPC4QvAsKtYguiGsmlH2SN3Mjx5LWd68Ok=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
+        "rev": "fab14c7b63499d57cb6673d5690168c3ec42b99a",
         "type": "github"
       },
       "original": {
@@ -260,11 +238,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1782379505,
-        "narHash": "sha256-zPvPiU+a7pqtH47xrtZLNRABJKpOjfZQclDbcvNtH+I=",
+        "lastModified": 1782562157,
+        "narHash": "sha256-a7+T6QSeowynwZ1ZJJbP8T8ntAytvrui8kFGJmIZt2c=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "603d3afd1b6145bd66e97ae38a34d91c95df70cf",
+        "rev": "a9cf7546a938c737b079e738de73934a13de9784",
         "type": "github"
       },
       "original": {
@@ -303,11 +281,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -362,11 +340,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782165805,
-        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`4751eb4`](https://github.com/sadjow/codex-cli-nix/commit/4751eb49f905fc1760b9f6ee7120bf5c32f4eb56) -> [`848bccf`](https://github.com/sadjow/codex-cli-nix/commit/848bccf577af78fed932a7a16813e0628952405d) ([compare](https://github.com/sadjow/codex-cli-nix/compare/4751eb49f905fc1760b9f6ee7120bf5c32f4eb56...848bccf577af78fed932a7a16813e0628952405d))
- `git-hooks-nix`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`3bbec39`](https://github.com/cachix/git-hooks.nix/commit/3bbec39bc90eadfa031e6f3b77272f3f60803e39) -> [`bca82ca`](https://github.com/cachix/git-hooks.nix/commit/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe) ([compare](https://github.com/cachix/git-hooks.nix/compare/3bbec39bc90eadfa031e6f3b77272f3f60803e39...bca82caa46d5ec0f5d422c61fb1e30bc51313cbe))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`5d320ab`](https://github.com/nix-community/home-manager/commit/5d320ab301cfaaca7d32514f13815d19d109f5f4) -> [`a1645f4`](https://github.com/nix-community/home-manager/commit/a1645f40777620c4bd2b6d854b290c2fc354a266) ([compare](https://github.com/nix-community/home-manager/compare/5d320ab301cfaaca7d32514f13815d19d109f5f4...a1645f40777620c4bd2b6d854b290c2fc354a266))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`17848a5`](https://github.com/ryoppippi/nix-claude-code/commit/17848a5b5beb2b9b4256c5e9c2873a634f62fc08) -> [`461ae41`](https://github.com/ryoppippi/nix-claude-code/commit/461ae41f8cf53e021400e122b3a3fa559cf987f1) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/17848a5b5beb2b9b4256c5e9c2873a634f62fc08...461ae41f8cf53e021400e122b3a3fa559cf987f1))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`3017088`](https://github.com/Mic92/nix-index-database/commit/3017088b49efd404f78e3b104f553b97e4af786b) -> [`fab14c7`](https://github.com/Mic92/nix-index-database/commit/fab14c7b63499d57cb6673d5690168c3ec42b99a) ([compare](https://github.com/Mic92/nix-index-database/compare/3017088b49efd404f78e3b104f553b97e4af786b...fab14c7b63499d57cb6673d5690168c3ec42b99a))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`603d3af`](https://github.com/nixos/nixos-hardware/commit/603d3afd1b6145bd66e97ae38a34d91c95df70cf) -> [`a9cf754`](https://github.com/nixos/nixos-hardware/commit/a9cf7546a938c737b079e738de73934a13de9784) ([compare](https://github.com/nixos/nixos-hardware/compare/603d3afd1b6145bd66e97ae38a34d91c95df70cf...a9cf7546a938c737b079e738de73934a13de9784))
- `nixpkgs_2`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`567a49d`](https://github.com/nixos/nixpkgs/commit/567a49d1913ce81ac6e9582e3553dd90a955875f) -> [`d407951`](https://github.com/nixos/nixpkgs/commit/d407951447dcd00442e97087bf374aad70c04cea) ([compare](https://github.com/nixos/nixpkgs/compare/567a49d1913ce81ac6e9582e3553dd90a955875f...d407951447dcd00442e97087bf374aad70c04cea))
- `sops-nix`: [`Mic92/sops-nix`](https://github.com/Mic92/sops-nix) [`56b2406`](https://github.com/Mic92/sops-nix/commit/56b24064fdcaedca53553b1a6d607fd23b613a24) -> [`f140661`](https://github.com/Mic92/sops-nix/commit/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9) ([compare](https://github.com/Mic92/sops-nix/compare/56b24064fdcaedca53553b1a6d607fd23b613a24...f1406619a3884cd5c47992a70b8b35c9c0fcb4c9))
