### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782875821,
-        "narHash": "sha256-Xii/zDQ2VB+Hpf5JHxWbk2PI6LOlFeIiZFGkTWqOQ+0=",
+        "lastModified": 1784484188,
+        "narHash": "sha256-FM9Iwr775hfEdUwJsqRuKbi5QqR0JeYuWEyVrgF6C7s=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "848bccf577af78fed932a7a16813e0628952405d",
+        "rev": "fa13e0c1f4d0792481e68e057db31f26242de73b",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -180,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783222121,
-        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
+        "lastModified": 1784489491,
+        "narHash": "sha256-j9maqjx1T8+ljAVntAdSI5hSGCm77QNZz64JF1rJNu0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
+        "rev": "3139deb8cafbe73b39b24451255b2fdd3426077e",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783113769,
-        "narHash": "sha256-NL+0uUZbJfre/K7+8HuM+2qgRJHPOcmIY2mCGKKavn8=",
+        "lastModified": 1784424673,
+        "narHash": "sha256-9OA3dCN2EcKKdWK3LegYyD7XY+qtZccDpf4GFN3qrkw=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "461ae41f8cf53e021400e122b3a3fa559cf987f1",
+        "rev": "08d1a170742f2a88a7a996adca476d50a7fbff30",
         "type": "github"
       },
       "original": {
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783233851,
-        "narHash": "sha256-jzisD+3wWZPC4QvAsKtYguiGsmlH2SN3Mjx5LWd68Ok=",
+        "lastModified": 1784440659,
+        "narHash": "sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "fab14c7b63499d57cb6673d5690168c3ec42b99a",
+        "rev": "4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1782562157,
-        "narHash": "sha256-a7+T6QSeowynwZ1ZJJbP8T8ntAytvrui8kFGJmIZt2c=",
+        "lastModified": 1784310968,
+        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "a9cf7546a938c737b079e738de73934a13de9784",
+        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
         "type": "github"
       },
       "original": {
@@ -281,11 +281,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`848bccf`](https://github.com/sadjow/codex-cli-nix/commit/848bccf577af78fed932a7a16813e0628952405d) -> [`fa13e0c`](https://github.com/sadjow/codex-cli-nix/commit/fa13e0c1f4d0792481e68e057db31f26242de73b) ([compare](https://github.com/sadjow/codex-cli-nix/compare/848bccf577af78fed932a7a16813e0628952405d...fa13e0c1f4d0792481e68e057db31f26242de73b))
- `git-hooks-nix`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`bca82ca`](https://github.com/cachix/git-hooks.nix/commit/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe) -> [`43b3c1a`](https://github.com/cachix/git-hooks.nix/commit/43b3c1ab9d40fb1dbb008f451988a91e375825e9) ([compare](https://github.com/cachix/git-hooks.nix/compare/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe...43b3c1ab9d40fb1dbb008f451988a91e375825e9))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`a1645f4`](https://github.com/nix-community/home-manager/commit/a1645f40777620c4bd2b6d854b290c2fc354a266) -> [`3139deb`](https://github.com/nix-community/home-manager/commit/3139deb8cafbe73b39b24451255b2fdd3426077e) ([compare](https://github.com/nix-community/home-manager/compare/a1645f40777620c4bd2b6d854b290c2fc354a266...3139deb8cafbe73b39b24451255b2fdd3426077e))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`461ae41`](https://github.com/ryoppippi/nix-claude-code/commit/461ae41f8cf53e021400e122b3a3fa559cf987f1) -> [`08d1a17`](https://github.com/ryoppippi/nix-claude-code/commit/08d1a170742f2a88a7a996adca476d50a7fbff30) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/461ae41f8cf53e021400e122b3a3fa559cf987f1...08d1a170742f2a88a7a996adca476d50a7fbff30))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`fab14c7`](https://github.com/Mic92/nix-index-database/commit/fab14c7b63499d57cb6673d5690168c3ec42b99a) -> [`4f8d52a`](https://github.com/Mic92/nix-index-database/commit/4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb) ([compare](https://github.com/Mic92/nix-index-database/compare/fab14c7b63499d57cb6673d5690168c3ec42b99a...4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`a9cf754`](https://github.com/nixos/nixos-hardware/commit/a9cf7546a938c737b079e738de73934a13de9784) -> [`779c32a`](https://github.com/nixos/nixos-hardware/commit/779c32a00155994c86cde8213a8dd4df139d4355) ([compare](https://github.com/nixos/nixos-hardware/compare/a9cf7546a938c737b079e738de73934a13de9784...779c32a00155994c86cde8213a8dd4df139d4355))
- `nixpkgs_2`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`d407951`](https://github.com/nixos/nixpkgs/commit/d407951447dcd00442e97087bf374aad70c04cea) -> [`61b7c44`](https://github.com/nixos/nixpkgs/commit/61b7c44c4073f0b827768aff0049561b5110ea5a) ([compare](https://github.com/nixos/nixpkgs/compare/d407951447dcd00442e97087bf374aad70c04cea...61b7c44c4073f0b827768aff0049561b5110ea5a))
