### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784484188,
-        "narHash": "sha256-FM9Iwr775hfEdUwJsqRuKbi5QqR0JeYuWEyVrgF6C7s=",
+        "lastModified": 1784658824,
+        "narHash": "sha256-TYW3rOz0V0NgXCTW+/GcdX5kNyRsMsxoS5FGRKmo0Jw=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "fa13e0c1f4d0792481e68e057db31f26242de73b",
+        "rev": "bd1773d0f796c93de7f4f00ea6c2469e95e44b62",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -131,45 +131,22 @@
           "sbomnix",
           "flake-compat"
         ],
-        "gitignore": "gitignore",
         "nixpkgs": [
           "sbomnix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "sbomnix",
-          "git-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -180,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784489491,
-        "narHash": "sha256-j9maqjx1T8+ljAVntAdSI5hSGCm77QNZz64JF1rJNu0=",
+        "lastModified": 1784588016,
+        "narHash": "sha256-ouZe80aWEhMLVMkqICFDN+JUw+0FJtCr/bh+hHtRtMg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3139deb8cafbe73b39b24451255b2fdd3426077e",
+        "rev": "deeb6b7eb7e0c44ae1819c051ce175bd92a85100",
         "type": "github"
       },
       "original": {
@@ -200,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784424673,
-        "narHash": "sha256-9OA3dCN2EcKKdWK3LegYyD7XY+qtZccDpf4GFN3qrkw=",
+        "lastModified": 1784665457,
+        "narHash": "sha256-ST6ToH2MQR9Pdm5VoGw5MBJd7VcP56atkvnb5RaDxbw=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "08d1a170742f2a88a7a996adca476d50a7fbff30",
+        "rev": "995fa854b109b9e82f01f9c4abd78b2b2dc201ae",
         "type": "github"
       },
       "original": {
@@ -266,11 +243,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -281,11 +258,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -297,11 +274,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -334,11 +311,11 @@
         "vulnix": "vulnix"
       },
       "locked": {
-        "lastModified": 1780995381,
-        "narHash": "sha256-q91Amk0tTbACseVLmvd3LhBixcACyskVHD7lo1mSf28=",
+        "lastModified": 1784641210,
+        "narHash": "sha256-sEJW9Qh2ZhT9nsA0jwr7INYvHWnF7pypd1L5bqkhs70=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "30c95eb2fc0c402300ee05354c5cf84c7e5f74e2",
+        "rev": "1e156d40bff4e4ccce75f321f6ae35f1b2ca4af6",
         "type": "github"
       },
       "original": {
@@ -425,11 +402,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1778651554,
-        "narHash": "sha256-QxkkaBVdIIot/YVxPuzUhjP7cDAp7U9iJXWozVTcuww=",
+        "lastModified": 1784627745,
+        "narHash": "sha256-EFbgwK/CPrP4EmSUH3LqYmtbra9lAxwpsf16ByfZeCc=",
         "owner": "nix-community",
         "repo": "vulnix",
-        "rev": "038b06e335c41d7d2dcbccbf4f821f95d7c17b16",
+        "rev": "c0a930a55f4ef7026a41bcc1d39261d92f488b8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`fa13e0c`](https://github.com/sadjow/codex-cli-nix/commit/fa13e0c1f4d0792481e68e057db31f26242de73b) -> [`bd1773d`](https://github.com/sadjow/codex-cli-nix/commit/bd1773d0f796c93de7f4f00ea6c2469e95e44b62) ([compare](https://github.com/sadjow/codex-cli-nix/compare/fa13e0c1f4d0792481e68e057db31f26242de73b...bd1773d0f796c93de7f4f00ea6c2469e95e44b62))
- `flake-parts`: [`hercules-ci/flake-parts`](https://github.com/hercules-ci/flake-parts) [`3107b77`](https://github.com/hercules-ci/flake-parts/commit/3107b77cd68437b9a76194f0f7f9c55f2329ca5b) -> [`17c9d6c`](https://github.com/hercules-ci/flake-parts/commit/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e) ([compare](https://github.com/hercules-ci/flake-parts/compare/3107b77cd68437b9a76194f0f7f9c55f2329ca5b...17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e))
- `git-hooks-nix_2`: [`cachix/git-hooks.nix`](https://github.com/cachix/git-hooks.nix) [`3cfd774`](https://github.com/cachix/git-hooks.nix/commit/3cfd774b0a530725a077e17354fbdb87ea1c4aad) -> [`43b3c1a`](https://github.com/cachix/git-hooks.nix/commit/43b3c1ab9d40fb1dbb008f451988a91e375825e9) ([compare](https://github.com/cachix/git-hooks.nix/compare/3cfd774b0a530725a077e17354fbdb87ea1c4aad...43b3c1ab9d40fb1dbb008f451988a91e375825e9))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`3139deb`](https://github.com/nix-community/home-manager/commit/3139deb8cafbe73b39b24451255b2fdd3426077e) -> [`deeb6b7`](https://github.com/nix-community/home-manager/commit/deeb6b7eb7e0c44ae1819c051ce175bd92a85100) ([compare](https://github.com/nix-community/home-manager/compare/3139deb8cafbe73b39b24451255b2fdd3426077e...deeb6b7eb7e0c44ae1819c051ce175bd92a85100))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`08d1a17`](https://github.com/ryoppippi/nix-claude-code/commit/08d1a170742f2a88a7a996adca476d50a7fbff30) -> [`995fa85`](https://github.com/ryoppippi/nix-claude-code/commit/995fa854b109b9e82f01f9c4abd78b2b2dc201ae) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/08d1a170742f2a88a7a996adca476d50a7fbff30...995fa854b109b9e82f01f9c4abd78b2b2dc201ae))
- `nixpkgs-lib`: [`nix-community/nixpkgs.lib`](https://github.com/nix-community/nixpkgs.lib) [`333c4e0`](https://github.com/nix-community/nixpkgs.lib/commit/333c4e0545a6da976206c74db8773a1645b5870a) -> [`db3f255`](https://github.com/nix-community/nixpkgs.lib/commit/db3f255737b94216eb71cce308e2912cf6bc2d7c) ([compare](https://github.com/nix-community/nixpkgs.lib/compare/333c4e0545a6da976206c74db8773a1645b5870a...db3f255737b94216eb71cce308e2912cf6bc2d7c))
- `nixpkgs_2`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`61b7c44`](https://github.com/nixos/nixpkgs/commit/61b7c44c4073f0b827768aff0049561b5110ea5a) -> [`241313f`](https://github.com/nixos/nixpkgs/commit/241313f4e8e508cb9b13278c2b0fa25b9ca27163) ([compare](https://github.com/nixos/nixpkgs/compare/61b7c44c4073f0b827768aff0049561b5110ea5a...241313f4e8e508cb9b13278c2b0fa25b9ca27163))
- `nixpkgs_3`: [`NixOS/nixpkgs`](https://github.com/NixOS/nixpkgs) [`0726a0e`](https://github.com/NixOS/nixpkgs/commit/0726a0ecb6d4e08f6adced58726b95db924cef57) -> [`241313f`](https://github.com/NixOS/nixpkgs/commit/241313f4e8e508cb9b13278c2b0fa25b9ca27163) ([compare](https://github.com/NixOS/nixpkgs/compare/0726a0ecb6d4e08f6adced58726b95db924cef57...241313f4e8e508cb9b13278c2b0fa25b9ca27163))
- `sbomnix`: [`tiiuae/sbomnix`](https://github.com/tiiuae/sbomnix) [`30c95eb`](https://github.com/tiiuae/sbomnix/commit/30c95eb2fc0c402300ee05354c5cf84c7e5f74e2) -> [`1e156d4`](https://github.com/tiiuae/sbomnix/commit/1e156d40bff4e4ccce75f321f6ae35f1b2ca4af6) ([compare](https://github.com/tiiuae/sbomnix/compare/30c95eb2fc0c402300ee05354c5cf84c7e5f74e2...1e156d40bff4e4ccce75f321f6ae35f1b2ca4af6))
- `vulnix`: [`nix-community/vulnix`](https://github.com/nix-community/vulnix) [`038b06e`](https://github.com/nix-community/vulnix/commit/038b06e335c41d7d2dcbccbf4f821f95d7c17b16) -> [`c0a930a`](https://github.com/nix-community/vulnix/commit/c0a930a55f4ef7026a41bcc1d39261d92f488b8b) ([compare](https://github.com/nix-community/vulnix/compare/038b06e335c41d7d2dcbccbf4f821f95d7c17b16...c0a930a55f4ef7026a41bcc1d39261d92f488b8b))
