### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784588016,
-        "narHash": "sha256-ouZe80aWEhMLVMkqICFDN+JUw+0FJtCr/bh+hHtRtMg=",
+        "lastModified": 1784789275,
+        "narHash": "sha256-cgRTWuG+u1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "deeb6b7eb7e0c44ae1819c051ce175bd92a85100",
+        "rev": "3b0e6bbd65869af1beadf5963a99befc179d209f",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784665457,
-        "narHash": "sha256-ST6ToH2MQR9Pdm5VoGw5MBJd7VcP56atkvnb5RaDxbw=",
+        "lastModified": 1784751698,
+        "narHash": "sha256-liH0Np0m6QNtD7A4KVTN/nq4zXCQJxaV433EW0P9A+Q=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "995fa854b109b9e82f01f9c4abd78b2b2dc201ae",
+        "rev": "6d50977520ac0fe1355a028529e8af0a1463befa",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1784310968,
-        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
+        "lastModified": 1784723954,
+        "narHash": "sha256-1CfD8ZUjCkTgjsneLZ/lxCHhgDfqxxE7/GX0MmsgiqA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
+        "rev": "a017f5b72210026af5b3ac5949f08d94380a6fbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`deeb6b7`](https://github.com/nix-community/home-manager/commit/deeb6b7eb7e0c44ae1819c051ce175bd92a85100) -> [`3b0e6bb`](https://github.com/nix-community/home-manager/commit/3b0e6bbd65869af1beadf5963a99befc179d209f) ([compare](https://github.com/nix-community/home-manager/compare/deeb6b7eb7e0c44ae1819c051ce175bd92a85100...3b0e6bbd65869af1beadf5963a99befc179d209f))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`995fa85`](https://github.com/ryoppippi/nix-claude-code/commit/995fa854b109b9e82f01f9c4abd78b2b2dc201ae) -> [`6d50977`](https://github.com/ryoppippi/nix-claude-code/commit/6d50977520ac0fe1355a028529e8af0a1463befa) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/995fa854b109b9e82f01f9c4abd78b2b2dc201ae...6d50977520ac0fe1355a028529e8af0a1463befa))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`779c32a`](https://github.com/nixos/nixos-hardware/commit/779c32a00155994c86cde8213a8dd4df139d4355) -> [`a017f5b`](https://github.com/nixos/nixos-hardware/commit/a017f5b72210026af5b3ac5949f08d94380a6fbd) ([compare](https://github.com/nixos/nixos-hardware/compare/779c32a00155994c86cde8213a8dd4df139d4355...a017f5b72210026af5b3ac5949f08d94380a6fbd))
