### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784789275,
-        "narHash": "sha256-cgRTWuG+u1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M=",
+        "lastModified": 1784913159,
+        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3b0e6bbd65869af1beadf5963a99befc179d209f",
+        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784751698,
-        "narHash": "sha256-liH0Np0m6QNtD7A4KVTN/nq4zXCQJxaV433EW0P9A+Q=",
+        "lastModified": 1784914168,
+        "narHash": "sha256-1rFAkvVsEwv1CvpBskeH1usU0CKcNZIY+zO7eHZekfI=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "6d50977520ac0fe1355a028529e8af0a1463befa",
+        "rev": "c179409e2d5146af81350e3bff82b024aacd0df9",
         "type": "github"
       },
       "original": {
@@ -258,11 +258,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
@@ -311,11 +311,11 @@
         "vulnix": "vulnix"
       },
       "locked": {
-        "lastModified": 1784641210,
-        "narHash": "sha256-sEJW9Qh2ZhT9nsA0jwr7INYvHWnF7pypd1L5bqkhs70=",
+        "lastModified": 1784898126,
+        "narHash": "sha256-x0IWm1ukLHwrbZuuv1dgWSz2/iFGzn2IJJy/HuJLS2c=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "1e156d40bff4e4ccce75f321f6ae35f1b2ca4af6",
+        "rev": "e09c803f99160330135d740561a2d2abdd61ba65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`3b0e6bb`](https://github.com/nix-community/home-manager/commit/3b0e6bbd65869af1beadf5963a99befc179d209f) -> [`079a3b5`](https://github.com/nix-community/home-manager/commit/079a3b5d1aa6a719920a51316253b7d6dd22738d) ([compare](https://github.com/nix-community/home-manager/compare/3b0e6bbd65869af1beadf5963a99befc179d209f...079a3b5d1aa6a719920a51316253b7d6dd22738d))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`6d50977`](https://github.com/ryoppippi/nix-claude-code/commit/6d50977520ac0fe1355a028529e8af0a1463befa) -> [`c179409`](https://github.com/ryoppippi/nix-claude-code/commit/c179409e2d5146af81350e3bff82b024aacd0df9) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/6d50977520ac0fe1355a028529e8af0a1463befa...c179409e2d5146af81350e3bff82b024aacd0df9))
- `nixpkgs_2`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`241313f`](https://github.com/nixos/nixpkgs/commit/241313f4e8e508cb9b13278c2b0fa25b9ca27163) -> [`e2587ca`](https://github.com/nixos/nixpkgs/commit/e2587caef70cea85dd97d7daab492899902dbf5d) ([compare](https://github.com/nixos/nixpkgs/compare/241313f4e8e508cb9b13278c2b0fa25b9ca27163...e2587caef70cea85dd97d7daab492899902dbf5d))
- `sbomnix`: [`tiiuae/sbomnix`](https://github.com/tiiuae/sbomnix) [`1e156d4`](https://github.com/tiiuae/sbomnix/commit/1e156d40bff4e4ccce75f321f6ae35f1b2ca4af6) -> [`e09c803`](https://github.com/tiiuae/sbomnix/commit/e09c803f99160330135d740561a2d2abdd61ba65) ([compare](https://github.com/tiiuae/sbomnix/compare/1e156d40bff4e4ccce75f321f6ae35f1b2ca4af6...e09c803f99160330135d740561a2d2abdd61ba65))
