### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784913159,
-        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
+        "lastModified": 1785168662,
+        "narHash": "sha256-kGJTc0oEUQuEwV66lSlMxYtOEtpk9N/HS43k+rFAvs8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
+        "rev": "cbb77679b3d992c8b62f884cd3a84af534a28621",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784914168,
-        "narHash": "sha256-1rFAkvVsEwv1CvpBskeH1usU0CKcNZIY+zO7eHZekfI=",
+        "lastModified": 1785117517,
+        "narHash": "sha256-O/CfoHSY6zyyrM53mHFhEzgJpikE9vEqLQAsQGRZGSo=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "c179409e2d5146af81350e3bff82b024aacd0df9",
+        "rev": "41739a8e4ebfd824676528327dd7ce6741bd19fa",
         "type": "github"
       },
       "original": {
@@ -197,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784440659,
-        "narHash": "sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4=",
+        "lastModified": 1785046085,
+        "narHash": "sha256-UiK+mmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb",
+        "rev": "11665045df8b9938ef811a3bfdc65cffb02b4b70",
         "type": "github"
       },
       "original": {
@@ -258,11 +258,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`079a3b5`](https://github.com/nix-community/home-manager/commit/079a3b5d1aa6a719920a51316253b7d6dd22738d) -> [`cbb7767`](https://github.com/nix-community/home-manager/commit/cbb77679b3d992c8b62f884cd3a84af534a28621) ([compare](https://github.com/nix-community/home-manager/compare/079a3b5d1aa6a719920a51316253b7d6dd22738d...cbb77679b3d992c8b62f884cd3a84af534a28621))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`c179409`](https://github.com/ryoppippi/nix-claude-code/commit/c179409e2d5146af81350e3bff82b024aacd0df9) -> [`41739a8`](https://github.com/ryoppippi/nix-claude-code/commit/41739a8e4ebfd824676528327dd7ce6741bd19fa) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/c179409e2d5146af81350e3bff82b024aacd0df9...41739a8e4ebfd824676528327dd7ce6741bd19fa))
- `nix-index-database`: [`Mic92/nix-index-database`](https://github.com/Mic92/nix-index-database) [`4f8d52a`](https://github.com/Mic92/nix-index-database/commit/4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb) -> [`1166504`](https://github.com/Mic92/nix-index-database/commit/11665045df8b9938ef811a3bfdc65cffb02b4b70) ([compare](https://github.com/Mic92/nix-index-database/compare/4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb...11665045df8b9938ef811a3bfdc65cffb02b4b70))
- `nixpkgs_2`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`e2587ca`](https://github.com/nixos/nixpkgs/commit/e2587caef70cea85dd97d7daab492899902dbf5d) -> [`624af66`](https://github.com/nixos/nixpkgs/commit/624af665418d3c65d544145b4d34ad696439570e) ([compare](https://github.com/nixos/nixpkgs/compare/e2587caef70cea85dd97d7daab492899902dbf5d...624af665418d3c65d544145b4d34ad696439570e))
