### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784658824,
-        "narHash": "sha256-TYW3rOz0V0NgXCTW+/GcdX5kNyRsMsxoS5FGRKmo0Jw=",
+        "lastModified": 1785294467,
+        "narHash": "sha256-mylUWHK2wIw8S07K5hbkrLELnflJkDwsSWz2YFbJzLI=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "bd1773d0f796c93de7f4f00ea6c2469e95e44b62",
+        "rev": "e4e3b0672bbb8fba7f32fe53cd9c604990970374",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785168662,
-        "narHash": "sha256-kGJTc0oEUQuEwV66lSlMxYtOEtpk9N/HS43k+rFAvs8=",
+        "lastModified": 1785306346,
+        "narHash": "sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14+gglFo/BhGJ4g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cbb77679b3d992c8b62f884cd3a84af534a28621",
+        "rev": "e705714e918c3b11affcdd15db2cbe3a070420a0",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785117517,
-        "narHash": "sha256-O/CfoHSY6zyyrM53mHFhEzgJpikE9vEqLQAsQGRZGSo=",
+        "lastModified": 1785245720,
+        "narHash": "sha256-IQKFyjd8tbSiCrkeDqkDHRLB99778u09/FbWa0VF0EU=",
         "owner": "ryoppippi",
         "repo": "nix-claude-code",
-        "rev": "41739a8e4ebfd824676528327dd7ce6741bd19fa",
+        "rev": "244eebacc228d42a27aa843695621dbe07a72e71",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1784723954,
-        "narHash": "sha256-1CfD8ZUjCkTgjsneLZ/lxCHhgDfqxxE7/GX0MmsgiqA=",
+        "lastModified": 1785232496,
+        "narHash": "sha256-65EQYIRRpTdpH8lUiB6Mvo5uBkG60aBIzAJuALfx+O0=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "a017f5b72210026af5b3ac5949f08d94380a6fbd",
+        "rev": "2e790b0a6be8ec2b76174ac0931b8ff11919ec98",
         "type": "github"
       },
       "original": {
@@ -258,11 +258,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

- Updated all flake inputs with `nix flake update`.
- Verified `nix build .#checks.x86_64-linux.x1-vm-smoke -L`.

### Updated Inputs
- `codex-cli-nix`: [`sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix) [`bd1773d`](https://github.com/sadjow/codex-cli-nix/commit/bd1773d0f796c93de7f4f00ea6c2469e95e44b62) -> [`e4e3b06`](https://github.com/sadjow/codex-cli-nix/commit/e4e3b0672bbb8fba7f32fe53cd9c604990970374) ([compare](https://github.com/sadjow/codex-cli-nix/compare/bd1773d0f796c93de7f4f00ea6c2469e95e44b62...e4e3b0672bbb8fba7f32fe53cd9c604990970374))
- `home-manager`: [`nix-community/home-manager`](https://github.com/nix-community/home-manager) [`cbb7767`](https://github.com/nix-community/home-manager/commit/cbb77679b3d992c8b62f884cd3a84af534a28621) -> [`e705714`](https://github.com/nix-community/home-manager/commit/e705714e918c3b11affcdd15db2cbe3a070420a0) ([compare](https://github.com/nix-community/home-manager/compare/cbb77679b3d992c8b62f884cd3a84af534a28621...e705714e918c3b11affcdd15db2cbe3a070420a0))
- `nix-claude-code`: [`ryoppippi/nix-claude-code`](https://github.com/ryoppippi/nix-claude-code) [`41739a8`](https://github.com/ryoppippi/nix-claude-code/commit/41739a8e4ebfd824676528327dd7ce6741bd19fa) -> [`244eeba`](https://github.com/ryoppippi/nix-claude-code/commit/244eebacc228d42a27aa843695621dbe07a72e71) ([compare](https://github.com/ryoppippi/nix-claude-code/compare/41739a8e4ebfd824676528327dd7ce6741bd19fa...244eebacc228d42a27aa843695621dbe07a72e71))
- `nixos-hardware`: [`nixos/nixos-hardware`](https://github.com/nixos/nixos-hardware) [`a017f5b`](https://github.com/nixos/nixos-hardware/commit/a017f5b72210026af5b3ac5949f08d94380a6fbd) -> [`2e790b0`](https://github.com/nixos/nixos-hardware/commit/2e790b0a6be8ec2b76174ac0931b8ff11919ec98) ([compare](https://github.com/nixos/nixos-hardware/compare/a017f5b72210026af5b3ac5949f08d94380a6fbd...2e790b0a6be8ec2b76174ac0931b8ff11919ec98))
- `nixpkgs_2`: [`nixos/nixpkgs`](https://github.com/nixos/nixpkgs) [`624af66`](https://github.com/nixos/nixpkgs/commit/624af665418d3c65d544145b4d34ad696439570e) -> [`0954f7e`](https://github.com/nixos/nixpkgs/commit/0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5) ([compare](https://github.com/nixos/nixpkgs/compare/624af665418d3c65d544145b4d34ad696439570e...0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5))
